### PR TITLE
feat(015): Generate Makefile in planning output

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -2576,6 +2576,12 @@ function writeTemplateArtifacts(repoRoot, input, output, outdir, config) {
   }
 }
 
+function writeMakefile(repoRoot, outdir) {
+  const templatePath = path.join(repoRoot, "templates", "Makefile.template");
+  const makefileContent = readText(templatePath, "Makefile.template");
+  writeFile(path.join(outdir, "Makefile"), makefileContent);
+}
+
 function printSummary(output, outdir, validateOnly) {
   const firstWave = output.executionWaves[0];
   const firstWaveTasks = firstWave
@@ -2656,6 +2662,7 @@ function main() {
     writeAiArtifacts(input, output, outdir);
     writeOperationalArtifacts(input, output, outdir, rerunReport);
     writeTemplateArtifacts(repoRoot, input, output, outdir, config);
+    writeMakefile(repoRoot, outdir);
     preservePreviousRunArtifacts(previousRun, rerunReport, outdir);
 
     if (args.summary) {

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -1,0 +1,37 @@
+.PHONY: install dev build test lint format ci clean help
+
+# Default target
+.DEFAULT_GOAL := help
+
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Available targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## Install dependencies
+	npm ci
+
+dev: ## Start development server
+	npm run dev
+
+build: ## Build for production
+	npm run build
+
+test: ## Run tests
+	npm test
+
+lint: ## Run linting and type-checking
+	npm run lint
+	npm run type-check
+
+format: ## Format code
+	npm run format
+
+format-check: ## Check code formatting
+	npm run format:check
+
+ci: format-check lint test build ## Run all CI checks (format, lint, test, build)
+
+clean: ## Remove build artifacts and dependencies
+	rm -rf node_modules .next dist build coverage


### PR DESCRIPTION
## Task 015: Generate Makefile in Planning Output

**Priority:** P0

### Problem
During ai-dashboard dogfooding, missing `make ci` caused 3 preventable CI failures. Developers pushed without local validation. No standardized way to run all checks locally before pushing.

### Solution
Generate a Makefile in the output directory with standardized targets for local validation before pushing.

### Implementation

**New File:**
- `templates/Makefile.template` (825 bytes)
  - 10 targets: install, dev, build, test, lint, format, format-check, ci, clean, help
  - Self-documenting help target (default)
  - Works on Linux and macOS

**Modified File:**
- `scripts/bootstrap-plan.js`
  - Added `writeMakefile(repoRoot, outdir)` function
  - Called after `writeTemplateArtifacts()`
  - Uses existing `readText()` and `writeFile()` infrastructure

### Makefile Targets

```makefile
make help          # Show available targets (default)
make install       # Install dependencies (npm ci)
make dev           # Start development server
make build         # Build for production
make test          # Run tests
make lint          # Run linting + type-checking
make format        # Format code
make format-check  # Check code formatting
make ci            # Run all CI checks (format-check + lint + test + build)
make clean         # Remove build artifacts (node_modules, .next, dist, etc.)
```

### Key Feature: `make ci`

The most important target for preventing CI failures:

```makefile
ci: format-check lint test build
```

Run this locally before pushing to catch issues early!

### Testing

**Existing Tests:**
✅ All 8 bootstrap-plan tests still pass
- Enterprise artifacts generation
- Config overrides
- Markdown input parsing
- Summary mode
- Resume-from functionality
- Validate-only mode
- Invalid input validation
- Invalid config validation

**Manual Verification:**
```bash
node scripts/bootstrap-plan.js --input examples/sample-input.json --outdir /tmp/test
ls -la /tmp/test/Makefile  # ✅ Generated!
cat /tmp/test/Makefile      # ✅ Correct content!
```

### Acceptance Criteria

- [x] `make ci` runs lint + test + build in sequence
- [x] `make install` sets up dependencies
- [x] Makefile generated for all profiles
- [x] Works on Linux and macOS
- [x] All existing tests pass

### Impact

**Before:**
- Developers manually run `npm run lint && npm run format:check && npm test && npm run build`
- Easy to forget steps → CI failures
- No standardized workflow

**After:**
- Single command: `make ci`
- Self-documenting: `make help`
- Consistent across all planforge-generated projects
- Prevents 3 common CI failure scenarios from ai-dashboard dogfooding

### Next Steps

After merge:
- Task 019: Post-generate lock file (package-lock.json)
- Task 016: Docker dev environment
- Task 017: Pre-commit hooks

---

**Related:**
- Dogfooding learnings from ai-dashboard (8 tasks, 9.1/10 average)
- Tool-Gap #6 identified during implementation