### PR TITLE
fix: matchPattern uses best-match instead of first-match

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -907,17 +907,25 @@ function loadStackPatterns(repoRoot) {
 
 function matchPattern(feature, patterns) {
   const lower = feature.toLowerCase();
+  const matches = [];
   
   for (const [patternName, pattern] of Object.entries(patterns)) {
     const keywords = pattern.keywords || [];
     const matchCount = keywords.filter(keyword => lower.includes(keyword)).length;
     
     if (matchCount > 0) {
-      return { patternName, pattern, matchCount };
+      matches.push({ patternName, pattern, matchCount });
     }
   }
   
-  return null;
+  if (matches.length === 0) {
+    return null;
+  }
+  
+  // Sort by matchCount descending (best match first)
+  matches.sort((a, b) => b.matchCount - a.matchCount);
+  
+  return matches[0];
 }
 
 function featureFiles(feature, architectureShape, stackPatterns) {


### PR DESCRIPTION
Fixes #10

## Problem
`matchPattern()` returned the first pattern with `matchCount > 0`, not the best match. This caused non-deterministic behavior depending on `Object.entries()` iteration order.

## Bug Scenario

**Feature:** "User authentication with JWT and login dashboard"

**Pattern Matching:**
- `authentication-jwt`: keywords `["authentication", "jwt", "auth", "login"]` → matchCount = 3
- `dashboard-widgets`: keywords `["dashboard"]` → matchCount = 1

**Before (first-match):**
- If `dashboard-widgets` appears first in `Object.entries()` → returns dashboard ❌
- If `authentication-jwt` appears first → returns auth ✅
- **Non-deterministic!**

**After (best-match):**
- Collects both: `[{auth, 3}, {dashboard, 1}]`
- Sorts by matchCount descending: `[{auth, 3}, {dashboard, 1}]`
- Returns `authentication-jwt` ✅
- **Deterministic!**

## Solution

Collect all patterns with `matchCount > 0`, sort by `matchCount` descending, return the best match.

```javascript
function matchPattern(feature, patterns) {
  const lower = feature.toLowerCase();
  const matches = [];
  
  for (const [patternName, pattern] of Object.entries(patterns)) {
    const keywords = pattern.keywords || [];
    const matchCount = keywords.filter(keyword => lower.includes(keyword)).length;
    
    if (matchCount > 0) {
      matches.push({ patternName, pattern, matchCount });
    }
  }
  
  if (matches.length === 0) {
    return null;
  }
  
  // Sort by matchCount descending (best match first)
  matches.sort((a, b) => b.matchCount - a.matchCount);
  
  return matches[0];
}
```

## Testing

**Existing Tests:**
✅ All 8 bootstrap-plan tests pass

**Manual Verification:**
```bash
# Create ambiguous feature
echo '{"projectName":"Test","coreFeatures":["User authentication with JWT and login dashboard"]}' > /tmp/test.json

node scripts/bootstrap-plan.js --input /tmp/test.json --outdir /tmp/test-output --no-install

cat /tmp/test-output/tasks/003-*.md | grep -A5 "Files To Create"
# ✅ Shows lib/auth/* files (authentication pattern)
# ✅ NOT dashboard widget files
```

## Impact

- ✅ Deterministic pattern matching
- ✅ Best match always wins
- ✅ Prevents wrong pattern selection
- ✅ No breaking changes (improves existing logic)
- ✅ Handles ambiguous features correctly