### PR TITLE
refactor: writeBranchInfo uses direct placeholders

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -2678,10 +2678,13 @@ function writeBranchInfo(repoRoot, outdir, defaultBranch, autoDetected) {
   const templatePath = path.join(repoRoot, "templates", "BRANCH_INFO.md.template");
   let content = readText(templatePath, "BRANCH_INFO.md.template");
   
-  // Simple template replacement (planforge doesn't use a template engine)
+  // Simple template replacement with direct placeholders
+  const detectionMethod = autoDetected 
+    ? "auto-detected from the repository" 
+    : "configured in the planning input";
+  
   content = content.replace(/{{defaultBranch}}/g, defaultBranch);
-  content = content.replace(/{{#if autoDetected}}auto-detected from the repository{{else}}configured in the planning input{{\/if}}/g, 
-    autoDetected ? "auto-detected from the repository" : "configured in the planning input");
+  content = content.replace(/{{detectionMethod}}/g, detectionMethod);
   
   writeFile(path.join(outdir, "BRANCH_INFO.md"), content);
 }

--- a/templates/BRANCH_INFO.md.template
+++ b/templates/BRANCH_INFO.md.template
@@ -6,7 +6,7 @@ This project uses **{{defaultBranch}}** as the default branch.
 
 **Default Branch:** `{{defaultBranch}}`
 
-This branch name was {{#if autoDetected}}auto-detected from the repository{{else}}configured in the planning input{{/if}}.
+This branch name was {{detectionMethod}}.
 
 ## CI/CD Integration
 


### PR DESCRIPTION
Fixes #9

## Problem
`writeBranchInfo()` used fragile string-replace on Handlebars-like conditional syntax that would break if the template evolves.

**Before:**
```javascript
content.replace(/{{#if autoDetected}}auto-detected from the repository{{else}}configured in the planning input{{\/if}}/g, 
  autoDetected ? "auto-detected from the repository" : "configured in the planning input");
```

Issues:
- ❌ Fragile regex with escaped characters
- ❌ Logic mixed with template syntax  
- ❌ Hard to read and maintain
- ❌ Breaks if template text changes

## Solution
Replace conditional template syntax with a simple direct placeholder. Calculate the value in code, not in regex.

**Template Change:**
```markdown
<!-- Before -->
This branch name was {{#if autoDetected}}auto-detected from the repository{{else}}configured in the planning input{{/if}}.

<!-- After -->
This branch name was {{detectionMethod}}.
```

**Code Change:**
```javascript
function writeBranchInfo(repoRoot, outdir, defaultBranch, autoDetected) {
  const templatePath = path.join(repoRoot, "templates", "BRANCH_INFO.md.template");
  let content = readText(templatePath, "BRANCH_INFO.md.template");
  
  // Clean: logic in code, simple placeholder in template
  const detectionMethod = autoDetected 
    ? "auto-detected from the repository" 
    : "configured in the planning input";
  
  content = content.replace(/{{defaultBranch}}/g, defaultBranch);
  content = content.replace(/{{detectionMethod}}/g, detectionMethod);
  
  writeFile(path.join(outdir, "BRANCH_INFO.md"), content);
}
```

## Benefits

**Simpler:**
- ✅ No Handlebars-like conditional syntax
- ✅ Direct placeholder replacement
- ✅ Easier to understand

**Maintainable:**
- ✅ Logic in code where it belongs
- ✅ Template is just markup
- ✅ Easy to extend (add more placeholders)

**Robust:**
- ✅ No fragile regex
- ✅ Won't break if template text changes
- ✅ Clear separation of concerns

## Testing

**Existing Tests:**
✅ All 8 bootstrap-plan tests pass

**Manual Verification:**

**Auto-detected branch:**
```bash
node scripts/bootstrap-plan.js --input examples/minimal-input.json --outdir /tmp/test --no-install
cat /tmp/test/BRANCH_INFO.md | grep "branch name was"
# Output: "This branch name was auto-detected from the repository."
```

**Configured branch:**
```bash
echo '{"projectName":"Test","defaultBranch":"develop",...}' > /tmp/input.json
node scripts/bootstrap-plan.js --input /tmp/input.json --outdir /tmp/test2 --no-install
cat /tmp/test2/BRANCH_INFO.md | grep "branch name was"
# Output: "This branch name was configured in the planning input."
```

## Impact

**No Breaking Changes:**
- Same output format
- Same behavior
- Just cleaner, more maintainable implementation

**Before vs After:**

| Aspect | Before | After |
|--------|--------|-------|
| Template | Handlebars-like conditionals | Simple placeholders |
| Regex | Fragile, escaped | Simple, clean |
| Logic | Mixed with regex | In code |
| Maintainability | Hard | Easy |
| Extensibility | Difficult | Simple |

**Future-proof:** Easy to add more placeholders (`{{repoUrl}}`, `{{ciProvider}}`, etc.) without regex complexity.