### PR TITLE
fix: sharpen alert-system keywords to avoid pipeline overlap

### DIFF
--- a/config/stack-patterns.json
+++ b/config/stack-patterns.json
@@ -343,7 +343,7 @@
       }
     },
     "alert-system": {
-      "keywords": ["alert", "notification", "failure", "monitoring", "incident", "warn", "error"],
+      "keywords": ["alert", "alerting", "notification", "incident", "monitoring", "warn", "error", "severity", "acknowledge", "on-call", "pagerduty", "slack", "webhook", "trigger", "rule"],
       "files": {
         "nextjs-fullstack": [
           "lib/alerts/types.ts — Alert types (Alert, Severity, Status)",


### PR DESCRIPTION
Fixes #21 - See commit message for full details (7 → 15 keywords)