### PR TITLE
fix: pattern matching prioritizes primary keyword at feature start

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -920,9 +920,19 @@ function matchPattern(feature, patterns) {
   
   for (const [patternName, pattern] of Object.entries(patterns)) {
     const keywords = pattern.keywords || [];
-    const matchCount = keywords.filter(keyword => lower.includes(keyword)).length;
+    let matchCount = keywords.filter(keyword => lower.includes(keyword)).length;
     
     if (matchCount > 0) {
+      // Boost score if primary keyword appears at start of feature text
+      // e.g., "alert system" → "alert" at start = +10 bonus for alert-system pattern
+      const primaryKeyword = keywords[0];  // First keyword is usually primary
+      const wordsInFeature = lower.split(/\s+/);
+      const firstWord = wordsInFeature[0] || '';
+      
+      if (firstWord === primaryKeyword || firstWord.startsWith(primaryKeyword)) {
+        matchCount += 10;  // Strong boost for primary keyword at start
+      }
+      
       matches.push({ patternName, pattern, matchCount });
     }
   }


### PR DESCRIPTION
Fixes #21 (complete fix)

## Problem

Even after PR #24 keyword improvements, edge case still broken:

**Feature:** "Alert system for CI failures and deployment issues"
- alert-system: 1 match (alert)
- pipeline-monitoring: 2 matches (fail, deployment)
- Winner: pipeline ❌ (wrong!)

## Solution

Boost score +10 when primary keyword appears at start of feature text:

```javascript
const primaryKeyword = keywords[0];  // First keyword
const firstWord = feature.toLowerCase().split(/\s+/)[0];

if (firstWord === primaryKeyword || firstWord.startsWith(primaryKeyword)) {
  matchCount += 10;  // Strong boost
}
```

## Results

**"Alert system for CI failures":**
- alert-system: 1 + 10 = 11 ("alert" at start)
- pipeline-monitoring: 2
- Winner: alert-system ✅

**"Pipeline run history":**
- pipeline-monitoring: 1 + 10 = 11 ("pipeline" at start)
- Winner: pipeline-monitoring ✅

**"GitHub repository health":**
- github-api: 1 + 10 = 11 ("github" at start)
- Winner: github-api ✅

## Why +10

Strong signal that feature name indicates pattern concept. Overrides keyword count in most cases.

## Time

~5 minutes