### PR TITLE
feat(server): bake scaffoldkit venv into the planforge container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,52 @@ jobs:
 
       - name: Run server tests
         run: npm run test:server
+
+  docker:
+    # Validate the full image builds end-to-end: node server + TS output +
+    # CLI + scaffoldkit Python venv + blueprint source tree. The smoke
+    # asserts scaffoldkit is wired correctly by invoking it the same way
+    # the HTTP service does at runtime.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: server/Dockerfile
+          tags: agent-planforge:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scaffoldkit CLI smoke via venv python
+        run: |
+          docker run --rm --entrypoint /opt/sk-venv/bin/python3 \
+            agent-planforge:ci -m scaffoldkit.cli --help
+
+      - name: Scaffoldkit CLI smoke via PATH
+        run: |
+          docker run --rm --entrypoint scaffoldkit \
+            agent-planforge:ci --help
+
+      - name: HTTP service boots + healthz green
+        run: |
+          docker run -d --name planforge-smoke \
+            -e PLANFORGE_SERVICE_TOKEN=ci-token \
+            -p 18223:8223 \
+            agent-planforge:ci
+          for i in 1 2 3 4 5; do
+            sleep 2
+            if curl -fsS http://localhost:18223/healthz; then echo; exit 0; fi
+          done
+          echo "healthz never came up"
+          docker logs planforge-smoke
+          exit 1
+
+      - name: Image size report
+        run: docker images agent-planforge:ci --format '{{.Size}}'

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,24 @@
-# Minimal Dockerfile for the planforge HTTP service.
+# Multi-stage Dockerfile for the planforge HTTP service.
 #
-# This image ships the planforge CLI (JS, at the repo root) plus the HTTP
-# service (TypeScript, in `server/`) and nothing else. It intentionally does
-# NOT include scaffoldkit / Python — that's a separate concern tracked in a
-# follow-up ticket and will layer onto this image when it lands.
+# Layers:
+#   1. `node-builder`   — installs server npm deps, builds the TS output
+#   2. `scaffoldkit`    — clones scaffoldkit, installs it into a pinned
+#                          Python venv at /opt/sk-venv. The clone stays at
+#                          /opt/scaffoldkit so `loadScaffoldkitContext()`
+#                          (scripts/bootstrap-plan.js:1036) finds its
+#                          `src/scaffoldkit/blueprints/` directory.
+#   3. final (`node:22-bookworm-slim`) — bundles the planforge CLI,
+#                          the compiled server, and both scaffoldkit
+#                          artifacts, then runs the Hono HTTP service.
+#
+# We use `bookworm-slim` (Debian) rather than Alpine because the
+# scaffoldkit venv built in stage 2 would otherwise ship glibc-linked
+# CPython and fail to execute on musl. The image-size trade-off (~40 MB)
+# is worth the robustness.
+#
+# Scaffoldkit is pinned to a commit rather than tracking main so a
+# breaking change upstream doesn't silently ride in on a planforge
+# rebuild. Bump deliberately.
 #
 # Build from the repo root:
 #   docker build -f server/Dockerfile -t agent-planforge .
@@ -13,11 +28,10 @@
 #     -e PLANFORGE_SERVICE_TOKEN=<token> \
 #     agent-planforge
 
-FROM node:22-alpine AS builder
+# ─── Stage 1: Node/TS build ─────────────────────────────────────────────────
+FROM node:22-bookworm-slim AS node-builder
 WORKDIR /app
 
-# Server sub-package has its own package.json; install and build it first so
-# the slow step (npm install) is cached independently of the CLI code below.
 COPY server/package.json server/package-lock.json ./server/
 RUN cd server && npm ci
 
@@ -25,12 +39,59 @@ COPY server/tsconfig.json server/
 COPY server/src ./server/src
 RUN cd server && npm run build
 
-FROM node:22-alpine
+# ─── Stage 2: Scaffoldkit venv ──────────────────────────────────────────────
+# Pinned to 3.11 because the final stage pulls Debian-Bookworm's
+# python3 (= 3.11) via apt. Using 3.12 in the builder would mismatch
+# and the venv's python3 binary would fail at runtime with
+# `cannot open shared object file: libpython3.12.so.1.0`.
+FROM python:3.11-slim AS scaffoldkit
+# Pinned to https://github.com/LanNguyenSi/scaffoldkit @ 333e0f7 (2026-04).
+# Update this when bumping scaffoldkit; image build will pull a fresh
+# clone and rebuild the venv.
+ARG SCAFFOLDKIT_REF=333e0f7
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/LanNguyenSi/scaffoldkit.git /opt/scaffoldkit \
+ && cd /opt/scaffoldkit \
+ && git checkout "$SCAFFOLDKIT_REF" \
+ && rm -rf .git
+
+# The venv's own scripts shebang `#!/opt/sk-venv/bin/python3` works on
+# the final image because the Bookworm `python3` package (= 3.11)
+# provides the matching libpython3.11.so.1.0. No `--copies` needed —
+# symlinking into the system python keeps the venv small.
+RUN python3 -m venv /opt/sk-venv \
+ && /opt/sk-venv/bin/pip install --no-cache-dir --upgrade pip \
+ && /opt/sk-venv/bin/pip install --no-cache-dir /opt/scaffoldkit
+
+# Smoke: verify the CLI entry is reachable inside the venv. If this
+# line fails, the image build fails — better here than at runtime.
+RUN /opt/sk-venv/bin/scaffoldkit --help > /dev/null
+
+# ─── Stage 3: runtime ──────────────────────────────────────────────────────
+FROM node:22-bookworm-slim
 WORKDIR /app
 
-# The CLI lives at the repo root — copy the minimum it needs at runtime.
-# Installed production deps of the root (ajv, etc.) come via the root's own
-# npm install; this stays separate from the server install.
+# Python runtime + ca-certs. The scaffoldkit venv is a Python-3.11
+# build (see stage 2 comment); Bookworm ships 3.11 as its `python3`, so
+# installing it here gives the venv the matching `libpython3.11.so.1.0`
+# it needs at runtime. `--no-install-recommends` keeps the image from
+# dragging in a GUI toolchain along with the interpreter.
+#
+# The venv's python3 symlink points at `/usr/local/bin/python3` (the
+# location of python on the builder's `python:3.11-slim` base), but
+# Bookworm's apt installs python3 at `/usr/bin/python3`. Symlink from
+# the expected builder path to the apt-installed path so the venv's
+# scripts work without being rewritten.
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y python3 ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -s /usr/bin/python3 /usr/local/bin/python3
+
+# The CLI (and its root package.json) live at the repo root.
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
@@ -41,14 +102,37 @@ COPY examples ./examples
 COPY templates ./templates
 COPY playbooks ./playbooks
 
-# Server runtime — only the built output and production deps.
-COPY --from=builder /app/server/package.json ./server/
-COPY --from=builder /app/server/package-lock.json ./server/
-COPY --from=builder /app/server/dist ./server/dist
+# Server runtime — only built output and prod deps.
+COPY --from=node-builder /app/server/package.json ./server/
+COPY --from=node-builder /app/server/package-lock.json ./server/
+COPY --from=node-builder /app/server/dist ./server/dist
 RUN cd server && npm ci --omit=dev
 
-ENV PLANFORGE_ROOT=/app
-ENV PORT=8223
+# Scaffoldkit venv + source clone. The source clone is what
+# `loadScaffoldkitContext()` reads for blueprint metadata; the venv
+# holds the CLI entry the service subprocess-spawns.
+COPY --from=scaffoldkit /opt/sk-venv /opt/sk-venv
+COPY --from=scaffoldkit /opt/scaffoldkit /opt/scaffoldkit
+
+ENV PLANFORGE_ROOT=/app \
+    PORT=8223 \
+    SCAFFOLDKIT_ROOT=/opt/scaffoldkit \
+    SCAFFOLDKIT_PYTHON=/opt/sk-venv/bin/python3
+
+# Prepend the venv to PATH so `scaffoldkit` is callable bare. Done in a
+# separate ENV because `$PATH` expansion inside the multi-line ENV above
+# would refer to whatever PATH Docker had set at ENV-processing time
+# (often empty or the base image's default) rather than the image's
+# runtime PATH — subtle enough to silently break the smoke below.
+ENV PATH=/opt/sk-venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 EXPOSE 8223
+
+# Sanity check at image bake: a real invocation that exercises the
+# import path planforge uses at runtime (`python -m scaffoldkit.cli`).
+# Catches venv-copy regressions AND shebang mismatches. `--help` is
+# used as the smoke because scaffoldkit doesn't expose `--version`.
+RUN /opt/sk-venv/bin/python3 -m scaffoldkit.cli --help > /dev/null \
+ && scaffoldkit --help > /dev/null
 
 CMD ["node", "server/dist/index.js"]


### PR DESCRIPTION
Resolves 6f7d5e8b — follow-up #2 from project-forge ADR-0002. Adds scaffoldkit Python venv into the planforge image so the HTTP service can subprocess-spawn it.

Key Dockerfile changes: 3 stages (node-builder + scaffoldkit + runtime); pinned scaffoldkit commit 333e0f7; Alpine→Bookworm-slim (musl/glibc compatibility); Python 3.11 matched across stages; /usr/local/bin/python3 symlink for venv shebang. PATH prepends /opt/sk-venv/bin. In-image smoke runs python -m scaffoldkit.cli --help && scaffoldkit --help.

CI: new docker job builds with buildx+GHA cache, runs scaffoldkit smoke twice (venv python + PATH), boots full service, probes /healthz.

Image size 500MB (was 340MB) = +160MB delta, under the +200MB ticket budget.

Local smoke on VPS: healthz green, scaffoldkit runs both ways, POST /api/generate with sample-input streams progress+done SSE, request-id in tempdir path.