### PR TITLE
chore: add .relay.yml so ops dashboard can probe planforge

### DIFF
--- a/.relay.yml
+++ b/.relay.yml
@@ -1,0 +1,7 @@
+name: agent-planforge
+# /healthz is unauth by design (Traefik + ops probe). The service-token
+# gate only guards /api/*.
+health: /healthz
+health_port: 8223
+compose_file: server/Dockerfile
+rollback: true


### PR DESCRIPTION
Companion to project-forge deploy/planforge-http-service-slot. Adds .relay.yml at the repo root so the agent-relay on the VPS picks up agent-planforge during its /root/git scan and surfaces it in the deploy-panel ops dashboard. Health checks land on /healthz (unauth by design) — probe doesnt need PLANFORGE_SERVICE_TOKEN.

Task: 8d9fe14f-5631-4a13-b669-cc6d5f846bf0 (deploy-panel follow-up #4 from project-forge ADR-0002).