### PR TITLE
feat(server): include output tarball in the generate done event

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -26,7 +26,7 @@ Response: `Content-Type: text/event-stream`. Events:
 
 - `progress` — `{ requestId, stream: "stdout" | "stderr", line }` — one per
   CLI log line
-- `done` — `{ requestId, planOutput, scaffoldkitInput: <object> | null, exitCode: 0 }`
+- `done` — `{ requestId, planOutput, scaffoldkitInput: <object> | null, outputTarGz: <base64 gzip tarball>, exitCode: 0 }`. The tarball packs the **contents** of the CLI's output dir (not a nested `out/` folder); untar with `tar -xzf - -C <targetDir>`. Hard cap: 10 MiB (gzipped). Large enough for typical runs (~100 KB) and keeps a pathological prompt from streaming an unbounded blob into the client's memory.
 - `error` — `{ requestId, message, exitCode? }`
 
 ## Environment

--- a/server/src/generate.ts
+++ b/server/src/generate.ts
@@ -25,6 +25,10 @@ import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 export interface GenerateOptions {
   planforgeRoot: string;
@@ -65,10 +69,46 @@ export interface GenerateEvent {
   /** present on `done` — final artifacts read from the tempdir */
   planOutput?: unknown;
   scaffoldkitInput?: unknown;
+  /**
+   * Base64-encoded gzipped tarball of the CLI's output tempdir. Present on
+   * `done` so callers like project-forge can reconstruct the full file
+   * tree (planforge-index.json, planning/, handoff/, exports/, tasks/,
+   * architecture-overview.md, …) that the CLI wrote on disk. Encoding
+   * choice: base64 inside the SSE `data:` frame keeps the payload as a
+   * single atomic blob — no partial-tar delivery to handle on the client.
+   * Typical size for the sample input is ~60-120 KB; the cap at 10 MiB
+   * below keeps a pathological prompt from OOMing the service.
+   */
+  outputTarGz?: string;
   /** present on `error` */
   message?: string;
   /** subprocess exit code, present on `done` and `error` */
   exitCode?: number;
+}
+
+// Hard cap on the gzipped tarball that the `done` event carries. 10 MiB is
+// generous for a typical plan (~120 KB) and leaves headroom for large
+// handoff trees without letting a pathological run stream an unbounded
+// payload into the client's memory.
+const TARBALL_MAX_BYTES = 10 * 1024 * 1024;
+
+async function tarDir(dir: string): Promise<Buffer> {
+  // `-C dir .` tars the directory's CONTENTS rather than the dir itself —
+  // callers extract straight into their own tempdir without a nested
+  // `out/` layer.
+  //
+  // Note: this shells out to the system `tar`. That's present on every
+  // base image we care about (Debian bookworm-slim ships GNU tar). Going
+  // via shell instead of a Node tar library keeps the dep tree minimal.
+  const { stdout } = await execFileAsync(
+    "tar",
+    ["-czf", "-", "-C", dir, "."],
+    {
+      encoding: "buffer",
+      maxBuffer: TARBALL_MAX_BYTES,
+    },
+  );
+  return stdout;
 }
 
 export async function* runGenerate(
@@ -205,11 +245,39 @@ export async function* runGenerate(
       scaffoldkitInput = null;
     }
 
+    // Tar the full output tree so the caller can reconstruct the file
+    // layout the CLI wrote on disk. project-forge reads ~30 files from
+    // nested subdirectories (planning/, handoff/, exports/, tasks/) and
+    // needs all of them, not just the two JSON blobs above.
+    let outputTarGz: string | undefined;
+    try {
+      const buf = await tarDir(outdir);
+      if (buf.byteLength > TARBALL_MAX_BYTES) {
+        yield {
+          type: "error",
+          requestId,
+          message: `Output tarball exceeds ${TARBALL_MAX_BYTES} bytes`,
+          exitCode: 0,
+        };
+        return;
+      }
+      outputTarGz = buf.toString("base64");
+    } catch (err) {
+      yield {
+        type: "error",
+        requestId,
+        message: `Failed to tar output directory: ${(err as Error).message}`,
+        exitCode: 0,
+      };
+      return;
+    }
+
     yield {
       type: "done",
       requestId,
       planOutput,
       scaffoldkitInput,
+      outputTarGz,
       exitCode: 0,
     };
   } finally {

--- a/server/tests/routes.test.ts
+++ b/server/tests/routes.test.ts
@@ -210,6 +210,69 @@ describe("POST /api/generate — happy path", () => {
   );
 
   it(
+    "done event carries an outputTarGz that unpacks to the CLI's expected file layout",
+    async () => {
+      // The tarball is the contract project-forge relies on — it has to
+      // contain the file tree the CLI wrote (planning/, exports/, etc.)
+      // so the client can reconstruct the layout project-forge's
+      // downstream code (resolvePlanforgeOutputPaths, scaffoldkit
+      // invocation) reads from disk.
+      const res = await app.fetch(
+        new Request("http://test/api/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: AUTH },
+          body: JSON.stringify({ input: sampleInput }),
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      const events = await collectSSE(res.body);
+      const done = events.find((e) => e.event === "done")!.data as {
+        outputTarGz?: string;
+      };
+      expect(typeof done.outputTarGz).toBe("string");
+      expect(done.outputTarGz!.length).toBeGreaterThan(0);
+
+      // Unpack + inspect. Uses the same tools project-forge will use —
+      // system tar via a pipe, no extra deps.
+      const { spawn } = await import("node:child_process");
+      const { mkdtemp, rm, readdir } = await import("node:fs/promises");
+      const { tmpdir } = await import("node:os");
+      const { resolve } = await import("node:path");
+
+      const dir = await mkdtemp(resolve(tmpdir(), "planforge-untar-"));
+      try {
+        await new Promise<void>((resolveP, rejectP) => {
+          const child = spawn("tar", ["-xzf", "-", "-C", dir], {
+            stdio: ["pipe", "ignore", "pipe"],
+          });
+          child.on("error", rejectP);
+          child.on("close", (code) => {
+            if (code === 0) resolveP();
+            else rejectP(new Error(`tar exited ${code}`));
+          });
+          child.stdin.end(Buffer.from(done.outputTarGz!, "base64"));
+        });
+
+        const top = await readdir(dir);
+        // planforge-index.json is the sentinel the existing
+        // resolvePlanforgeOutputPaths() keys off of.
+        expect(top).toContain("planforge-index.json");
+        // exports/scaffoldkit-input.json is the handoff file
+        // project-forge feeds to the scaffoldkit CLI.
+        const exportsDir = await readdir(resolve(dir, "exports"));
+        expect(exportsDir).toContain("scaffoldkit-input.json");
+        // planning/plan-output.json — the canonical plan artifact.
+        const planningDir = await readdir(resolve(dir, "planning"));
+        expect(planningDir).toContain("plan-output.json");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  it(
     "does not log the request body (secret-safety)",
     async () => {
       // The ticket + ADR-0002 require that we never log request bodies;


### PR DESCRIPTION
Preparation for the project-forge client-swap (ticket 8080321b). Current POST /api/generate only returns two JSON blobs (plan-output + scaffoldkit-input); project-forge needs the whole tempDir tree (~30 files) to drive downstream code (scaffoldkit shell-out, post-scaffold review, preview read).

This PR adds outputTarGz (base64 gzip tarball of the CLI output dir contents) to the done SSE event. Hard cap 10 MiB. Uses system tar via execFile — no npm dep. New test unpacks the blob and asserts presence of planforge-index.json, exports/scaffoldkit-input.json, planning/plan-output.json.

Contract-lock before the client starts consuming it.