### PR TITLE
feat(server): invoke scaffoldkit and bundle scaffolded output into /generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,52 @@ jobs:
             agent-planforge:ci
           for i in 1 2 3 4 5; do
             sleep 2
-            if curl -fsS http://localhost:18223/healthz; then echo; exit 0; fi
+            if curl -fsS http://localhost:18223/healthz; then echo; break; fi
+            if [ "$i" = "5" ]; then
+              echo "healthz never came up"
+              docker logs planforge-smoke
+              exit 1
+            fi
           done
-          echo "healthz never came up"
-          docker logs planforge-smoke
-          exit 1
+
+      - name: Generate emits scaffolded files in the tarball
+        run: |
+          # Drive POST /api/generate against the running container with the
+          # repo's sample input. Assert the SSE `done` event's outputTarGz
+          # unpacks to a tree containing both planning artifacts AND
+          # scaffolded files — end-to-end proof that the HTTP service
+          # invokes scaffoldkit (venv shebang, blueprint copy, from-planforge
+          # wiring). Without this step, a broken scaffoldkit wiring would
+          # only surface once a real project-forge deploy tried it.
+          set -euo pipefail
+          BODY=$(jq -n --slurpfile input examples/sample-input.json '{input: $input[0]}')
+          RAW=$(mktemp)
+          curl -fsS --max-time 120 \
+            -H "Authorization: Bearer ci-token" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            http://localhost:18223/api/generate -o "$RAW"
+          # Pull the `done` frame out of the SSE stream.
+          DONE_DATA=$(awk 'BEGIN{RS="\n\n"} /^event: done/' "$RAW" | sed -n 's/^data: //p')
+          if [ -z "$DONE_DATA" ]; then
+            echo "No done event in SSE stream:"; cat "$RAW"; exit 1
+          fi
+          echo "$DONE_DATA" | jq -e '.scaffoldkit.invoked == true' \
+            || { echo "scaffoldkit was not invoked:"; echo "$DONE_DATA" | jq .scaffoldkit; exit 1; }
+          echo "$DONE_DATA" | jq -e '.scaffoldkit.exitCode == 0' \
+            || { echo "scaffoldkit exited nonzero:"; echo "$DONE_DATA" | jq .scaffoldkit; exit 1; }
+
+          OUTDIR=$(mktemp -d)
+          echo "$DONE_DATA" | jq -r '.outputTarGz' | base64 -d | tar -xzf - -C "$OUTDIR"
+          # Planning artifact — sentinel for the untouched pre-scaffold tree.
+          test -f "$OUTDIR/planforge-index.json" || { echo "missing planforge-index.json"; ls -la "$OUTDIR"; exit 1; }
+          # Scaffolded output — scaffoldkit's `from-planforge` writes a
+          # project tree alongside planforge's own `planning/` and
+          # `exports/`. A README.md at the top level is a stable
+          # scaffoldkit signature across blueprints.
+          test -f "$OUTDIR/README.md" || { echo "no scaffolded README.md at outdir top:"; find "$OUTDIR" -maxdepth 2 -type f | head -50; exit 1; }
+          echo "scaffolded tree sample:"
+          find "$OUTDIR" -maxdepth 2 -type f | head -30
 
       - name: Image size report
         run: docker images agent-planforge:ci --format '{{.Size}}'

--- a/server/README.md
+++ b/server/README.md
@@ -19,15 +19,37 @@ this package is follow-up ticket #1 from that ADR.
 Request:
 
 ```json
-{ "input": { /* planning input — same schema the CLI's --input accepts */ } }
+{
+  "input": { /* planning input — same schema the CLI's --input accepts */ },
+  "scaffold": true
+}
 ```
+
+- `scaffold` — optional, default `true`. When `true`, the service invokes
+  scaffoldkit against the planforge-produced `scaffoldkit-input.json` and
+  the resulting project tree lands in the response tarball alongside the
+  planning artifacts. Set to `false` for planning-only runs (preview UIs,
+  callers that scaffold separately, tests).
 
 Response: `Content-Type: text/event-stream`. Events:
 
 - `progress` — `{ requestId, stream: "stdout" | "stderr", line }` — one per
   CLI log line
-- `done` — `{ requestId, planOutput, scaffoldkitInput: <object> | null, outputTarGz: <base64 gzip tarball>, exitCode: 0 }`. The tarball packs the **contents** of the CLI's output dir (not a nested `out/` folder); untar with `tar -xzf - -C <targetDir>`. Hard cap: 10 MiB (gzipped). Large enough for typical runs (~100 KB) and keeps a pathological prompt from streaming an unbounded blob into the client's memory.
+- `done` — `{ requestId, planOutput, scaffoldkitInput: <object> | null, scaffoldkit: { invoked, exitCode?, stderr?, skipped? }, outputTarGz: <base64 gzip tarball>, exitCode: 0 }`. The tarball packs the **contents** of the CLI's output dir (not a nested `out/` folder); untar with `tar -xzf - -C <targetDir>`. Hard cap: 50 MiB (gzipped) — raised from 10 MiB when scaffolding landed because a scaffolded project tree can be several MB. Large enough for typical runs and keeps a pathological prompt from streaming an unbounded blob into the client's memory.
 - `error` — `{ requestId, message, exitCode? }`
+
+The `scaffoldkit` field on `done` always exists. Its `skipped` value
+tells callers why scaffolding was not performed:
+
+| `skipped` | Meaning |
+| --- | --- |
+| `opt_out` | Caller passed `scaffold: false` |
+| `no_input` | CLI did not write `scaffoldkit-input.json` (not every input produces one) |
+| `not_installed` | `SCAFFOLDKIT_PYTHON` is missing — dev env without the venv; production containers always have it |
+
+A nonzero `scaffoldkit.exitCode` does **not** fail the request — planning
+artifacts are still returned, and the caller decides whether the failed
+scaffold is fatal to its flow.
 
 ## Environment
 
@@ -37,6 +59,7 @@ Response: `Content-Type: text/event-stream`. Events:
 | `PLANFORGE_SERVICE_TOKEN` | *(required)* | Bearer token clients present |
 | `PLANFORGE_ROOT` | parent of this package | Repo root that contains `scripts/bootstrap-plan.js` |
 | `NODE_BIN` | `process.execPath` | Node binary used to spawn the CLI |
+| `SCAFFOLDKIT_PYTHON` | `/opt/sk-venv/bin/python3` | Python binary that runs `scaffoldkit.cli from-planforge`. The Dockerfile lays down the pinned venv; local dev points this at any Python that has scaffoldkit installed, or skips scaffolding via `scaffold: false` in the request body. |
 
 ## Running
 
@@ -74,13 +97,10 @@ is a few hundred milliseconds per test on a warm cache.
 
 This ticket ships the HTTP service layer only. The companion follow-ups:
 
-1. **Package the scaffoldkit Python venv into the image** (ticket
-   `6f7d5e8b-1262-461b-aec8-98532d63c78a`) — needed before planforge can
-   also run scaffold generation on behalf of its callers.
-2. **project-forge client swap** (ticket `8080321b-0919-4289-8bf7-26afe765e871`)
+1. **project-forge client swap** (ticket `8080321b-0919-4289-8bf7-26afe765e871`)
    — replace the two shell-outs in project-forge with one `POST /generate`.
-3. **deploy-panel compose slot + token distribution** (ticket
+2. **deploy-panel compose slot + token distribution** (ticket
    `8d9fe14f-5631-4a13-b669-cc6d5f846bf0`).
-
-Until #1 ships, `POST /generate` returns `plan-output` + `scaffoldkit-input.json`
-only; callers still run scaffoldkit themselves.
+3. **Drop Python from project-forge** (agent-tasks `31e6f7db`) — blocked on
+   this package running scaffoldkit in-container, which landed with the
+   `scaffoldkit` field on `done` and the 50 MiB tarball cap. Unblocked.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -16,6 +16,10 @@ const schema = z.object({
   // running Node, so containers that ship a single Node install get the
   // right value without configuration.
   NODE_BIN: z.string().default(process.execPath),
+  // Python binary that runs `scaffoldkit.cli from-planforge` after the
+  // planforge CLI writes `scaffoldkit-input.json`. The Dockerfile lays
+  // down a pinned venv at /opt/sk-venv; local dev / tests override.
+  SCAFFOLDKIT_PYTHON: z.string().default("/opt/sk-venv/bin/python3"),
 });
 
 function loadEnv() {

--- a/server/src/generate.ts
+++ b/server/src/generate.ts
@@ -10,15 +10,15 @@
  *   3. Spawn `node bootstrap-plan.js --input ${tmp}/input.json --outdir ${tmp}/out --no-install`
  *   4. Forward stdout/stderr lines to the caller as SSE `progress` events
  *   5. On clean exit: read `out/planning/plan-output.json` + `out/exports/scaffoldkit-input.json`
- *      and emit a `done` event containing both
- *   6. Always clean up the tempdir — success OR failure — so we never leak secrets in tmp
+ *   6. If scaffolding is enabled (default) AND scaffoldkit-input.json exists,
+ *      invoke `<SCAFFOLDKIT_PYTHON> -m scaffoldkit.cli from-planforge …`
+ *      against the same outdir so the tarball carries scaffolded files
+ *   7. Tar the outdir and emit a `done` event with plan output + scaffoldkit
+ *      metadata (exit code, stderr, skipped-reason if not invoked)
+ *   8. Always clean up the tempdir — success OR failure — so we never leak secrets in tmp
  *
  * Not handled in v1 (see ADR-0002 § "Risks"):
  *   - No resumption. A mid-run crash means the caller re-POSTs; no partial recovery.
- *   - No scaffoldkit invocation. The CLI writes `scaffoldkit-input.json`; running
- *     scaffoldkit itself stays on project-forge's side during the transition. A
- *     follow-up ticket extends this endpoint to include scaffolding once the
- *     Python venv lands in planforge's image.
  */
 import { spawn } from "node:child_process";
 import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
@@ -34,11 +34,45 @@ export interface GenerateOptions {
   planforgeRoot: string;
   nodeBin: string;
   /**
+   * Python binary that runs `scaffoldkit.cli from-planforge` after the
+   * planforge CLI writes `scaffoldkit-input.json`. The container sets
+   * this to the pinned venv; tests override to a stub or skip.
+   */
+  scaffoldkitPython: string;
+  /**
+   * Default true. When false, scaffolding is skipped — the `done` event
+   * still carries the planning tarball, just without scaffolded files.
+   * Callers that only want planning artifacts (e.g. a preview UI that
+   * scaffolds later, or tests) set this to false.
+   */
+  scaffold: boolean;
+  /**
    * When aborted, the CLI subprocess is killed with SIGTERM and the
    * generator exits on its next `yield`. The `finally` block still runs,
    * so the tempdir is cleaned up.
    */
   abortSignal?: AbortSignal;
+}
+
+/**
+ * Describes what happened with scaffoldkit for a given generate run.
+ * Always present on the `done` event so callers can tell the four cases
+ * apart without second-guessing:
+ *   - `invoked: true, exitCode: 0`       — scaffolding ran cleanly
+ *   - `invoked: true, exitCode: nonzero` — ran but failed; planning OK
+ *   - `invoked: false, skipped: "…"`     — intentionally not run
+ */
+export interface ScaffoldkitResult {
+  invoked: boolean;
+  exitCode?: number;
+  stderr?: string;
+  /**
+   * Reason scaffoldkit was not invoked.
+   * - `no_input`      — CLI didn't write scaffoldkit-input.json
+   * - `opt_out`       — caller passed `scaffold: false`
+   * - `not_installed` — SCAFFOLDKIT_PYTHON binary is missing (dev / tests)
+   */
+  skipped?: "no_input" | "opt_out" | "not_installed";
 }
 
 /**
@@ -80,17 +114,75 @@ export interface GenerateEvent {
    * below keeps a pathological prompt from OOMing the service.
    */
   outputTarGz?: string;
+  /** present on `done` — always populated so callers can branch on it */
+  scaffoldkit?: ScaffoldkitResult;
   /** present on `error` */
   message?: string;
   /** subprocess exit code, present on `done` and `error` */
   exitCode?: number;
 }
 
-// Hard cap on the gzipped tarball that the `done` event carries. 10 MiB is
-// generous for a typical plan (~120 KB) and leaves headroom for large
-// handoff trees without letting a pathological run stream an unbounded
-// payload into the client's memory.
-const TARBALL_MAX_BYTES = 10 * 1024 * 1024;
+// Hard cap on the gzipped tarball that the `done` event carries. The cap
+// was raised from 10 MiB → 50 MiB when scaffolding landed: scaffoldkit
+// emits a full project tree (source files, configs, lockfiles) that can
+// easily be several MB gzipped for a mid-size blueprint. 50 MiB still
+// refuses a pathological run that would OOM the client, while leaving
+// headroom ~10× typical scaffolded output (~2–5 MB).
+const TARBALL_MAX_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Invoke scaffoldkit against a planforge-produced `scaffoldkit-input.json`.
+ * Returns the child's exit code + captured stderr; never throws on a
+ * nonzero exit — that's surfaced to the caller as metadata so a failed
+ * scaffold doesn't mask a successful plan.
+ *
+ * ENOENT on the Python binary is re-thrown with a tagged message so the
+ * caller can distinguish "scaffoldkit not installed" from "scaffoldkit
+ * ran and failed".
+ */
+async function runScaffoldkit(args: {
+  python: string;
+  inputPath: string;
+  outdir: string;
+}): Promise<{ exitCode: number; stderr: string }> {
+  return await new Promise((resolvePromise, rejectPromise) => {
+    // Arg shape mirrors what project-forge has been running in the old
+    // subprocess path: `from-planforge <input> --target <outdir>
+    // --overwrite --no-install`. `--no-install` keeps the service off
+    // the network and prevents scaffoldkit from running `npm install`
+    // inside the HTTP service's tempdir.
+    const child = spawn(
+      args.python,
+      [
+        "-m",
+        "scaffoldkit.cli",
+        "from-planforge",
+        args.inputPath,
+        "--target",
+        args.outdir,
+        "--overwrite",
+        "--no-install",
+      ],
+      {
+        cwd: args.outdir,
+        env: buildChildEnv(),
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+      // Cap captured stderr at 64 KiB so a chatty scaffoldkit failure
+      // can't blow up the `done` event payload.
+      if (stderr.length > 65536) stderr = stderr.slice(0, 65536);
+    });
+    child.on("error", (err) => rejectPromise(err));
+    child.on("close", (code) => {
+      resolvePromise({ exitCode: code ?? -1, stderr });
+    });
+  });
+}
 
 async function tarDir(dir: string): Promise<Buffer> {
   // `-C dir .` tars the directory's CONTENTS rather than the dir itself —
@@ -236,13 +328,47 @@ export async function* runGenerate(
       };
       return;
     }
+    const scaffoldkitInputPath = resolve(outdir, "exports", "scaffoldkit-input.json");
     try {
-      scaffoldkitInput = JSON.parse(
-        await readFile(resolve(outdir, "exports", "scaffoldkit-input.json"), "utf8"),
-      );
+      scaffoldkitInput = JSON.parse(await readFile(scaffoldkitInputPath, "utf8"));
     } catch {
       // scaffoldkit-input.json is optional — not every input produces one.
       scaffoldkitInput = null;
+    }
+
+    // Run scaffoldkit if the CLI produced an input and the caller didn't
+    // opt out. Populate `scaffoldkit` metadata unconditionally so the
+    // caller can always branch on why files did/didn't end up in the tar.
+    let scaffoldkit: ScaffoldkitResult;
+    if (!opts.scaffold) {
+      scaffoldkit = { invoked: false, skipped: "opt_out" };
+    } else if (scaffoldkitInput === null) {
+      scaffoldkit = { invoked: false, skipped: "no_input" };
+    } else {
+      try {
+        const { exitCode, stderr } = await runScaffoldkit({
+          python: opts.scaffoldkitPython,
+          inputPath: scaffoldkitInputPath,
+          outdir,
+        });
+        scaffoldkit = { invoked: true, exitCode, stderr };
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          // Scaffoldkit python is not installed in this environment.
+          // Still emit `done` so planning artifacts aren't discarded;
+          // callers inspect `scaffoldkit.skipped` to decide.
+          scaffoldkit = { invoked: false, skipped: "not_installed" };
+        } else {
+          yield {
+            type: "error",
+            requestId,
+            message: `Failed to spawn scaffoldkit: ${(err as Error).message}`,
+            exitCode: 0,
+          };
+          return;
+        }
+      }
     }
 
     // Tar the full output tree so the caller can reconstruct the file
@@ -277,6 +403,7 @@ export async function* runGenerate(
       requestId,
       planOutput,
       scaffoldkitInput,
+      scaffoldkit,
       outputTarGz,
       exitCode: 0,
     };

--- a/server/src/generate.ts
+++ b/server/src/generate.ts
@@ -122,28 +122,64 @@ export interface GenerateEvent {
   exitCode?: number;
 }
 
-// Hard cap on the gzipped tarball that the `done` event carries. The cap
-// was raised from 10 MiB → 50 MiB when scaffolding landed: scaffoldkit
-// emits a full project tree (source files, configs, lockfiles) that can
-// easily be several MB gzipped for a mid-size blueprint. 50 MiB still
-// refuses a pathological run that would OOM the client, while leaving
-// headroom ~10× typical scaffolded output (~2–5 MB).
+// Hard cap on the gzipped tarball that the `done` event carries. Raised
+// from 10 MiB → 50 MiB when scaffolding landed: scaffoldkit emits a
+// full project tree (source files, configs, lockfiles) that can easily
+// be several MB gzipped for a mid-size blueprint. 50 MiB still refuses
+// a pathological run that would OOM the client, while leaving ~10×
+// headroom over typical scaffolded output (~2–5 MB).
+//
+// Alternative considered: keep the 10 MiB cap and error loudly when
+// scaffolding blows through it. Rejected because a realistic blueprint
+// exceeding 10 MiB is a normal operating mode, not an anomaly — we'd
+// be shipping a broken-by-default endpoint. The ~5× size bump is
+// acceptable because the only server-side caller today is project-forge's
+// Next.js route handler (not a browser), which has generous heap headroom.
+// Browser callers should opt out via `scaffold: false` and fetch the
+// scaffolded tree out-of-band.
 const TARBALL_MAX_BYTES = 50 * 1024 * 1024;
 
 /**
+ * Wall-clock cap on a single scaffoldkit invocation. 5 minutes is far
+ * longer than any real blueprint needs; anything hitting this is
+ * either hung or a bug, and we'd rather surface a deterministic
+ * `exitCode: -1 + stderr: "timeout …"` on the `done` event than let
+ * the HTTP request block indefinitely. Unitless here because vitest
+ * mocks the clock; plain integer ms.
+ */
+const SCAFFOLDKIT_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * Max captured scaffoldkit stderr that rides out on the `done` event.
+ * Kept deliberately small: scaffoldkit may echo user-supplied input
+ * values in its error messages, and the `done` frame is delivered to
+ * the HTTP caller where it may land in logs. A 4 KiB tail is enough
+ * for a debug signal without amplifying an accidental input leak.
+ * Callers that need the full stderr should run scaffoldkit locally.
+ */
+const SCAFFOLDKIT_STDERR_MAX_BYTES = 4096;
+
+/**
  * Invoke scaffoldkit against a planforge-produced `scaffoldkit-input.json`.
- * Returns the child's exit code + captured stderr; never throws on a
- * nonzero exit — that's surfaced to the caller as metadata so a failed
- * scaffold doesn't mask a successful plan.
+ * Returns the child's exit code + a capped captured stderr; never throws
+ * on a nonzero exit — that's surfaced to the caller as metadata so a
+ * failed scaffold doesn't mask a successful plan.
  *
- * ENOENT on the Python binary is re-thrown with a tagged message so the
- * caller can distinguish "scaffoldkit not installed" from "scaffoldkit
- * ran and failed".
+ * Timeout → SIGTERM → SIGKILL, with `exitCode: -1` + a clear stderr
+ * marker so callers can detect the timeout case in `done.scaffoldkit`.
+ *
+ * AbortSignal propagation: when the HTTP client disconnects mid-scaffold,
+ * the subprocess is killed so the server doesn't run orphaned work to
+ * completion.
+ *
+ * ENOENT on the Python binary is re-thrown so the caller can surface
+ * `skipped: "not_installed"` cleanly.
  */
 async function runScaffoldkit(args: {
   python: string;
   inputPath: string;
   outdir: string;
+  abortSignal?: AbortSignal;
 }): Promise<{ exitCode: number; stderr: string }> {
   return await new Promise((resolvePromise, rejectPromise) => {
     // Arg shape mirrors what project-forge has been running in the old
@@ -170,15 +206,50 @@ async function runScaffoldkit(args: {
       },
     );
     let stderr = "";
+    let timedOut = false;
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
-      // Cap captured stderr at 64 KiB so a chatty scaffoldkit failure
-      // can't blow up the `done` event payload.
-      if (stderr.length > 65536) stderr = stderr.slice(0, 65536);
+      if (stderr.length > SCAFFOLDKIT_STDERR_MAX_BYTES) {
+        stderr = stderr.slice(0, SCAFFOLDKIT_STDERR_MAX_BYTES);
+      }
     });
-    child.on("error", (err) => rejectPromise(err));
-    child.on("close", (code) => {
+
+    // Timeout watchdog: SIGTERM the child after SCAFFOLDKIT_TIMEOUT_MS.
+    // SIGKILL 5s later if it hasn't exited.
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      if (!child.killed) child.kill("SIGTERM");
+      const kill = setTimeout(() => {
+        if (!child.killed) child.kill("SIGKILL");
+      }, 5_000);
+      kill.unref?.();
+    }, SCAFFOLDKIT_TIMEOUT_MS);
+    timeout.unref?.();
+
+    // Abort propagation: when the HTTP client disconnects, kill the
+    // scaffold subprocess too. Without this, a hung scaffold keeps
+    // running on the server after the caller gave up.
+    const onAbort = () => {
+      if (!child.killed) child.kill("SIGTERM");
+    };
+    args.abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      args.abortSignal?.removeEventListener("abort", onAbort);
+      rejectPromise(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timeout);
+      args.abortSignal?.removeEventListener("abort", onAbort);
+      if (timedOut) {
+        resolvePromise({
+          exitCode: -1,
+          stderr: `scaffoldkit timed out after ${SCAFFOLDKIT_TIMEOUT_MS}ms (${signal ?? "terminated"})`,
+        });
+        return;
+      }
       resolvePromise({ exitCode: code ?? -1, stderr });
     });
   });
@@ -350,6 +421,7 @@ export async function* runGenerate(
           python: opts.scaffoldkitPython,
           inputPath: scaffoldkitInputPath,
           outdir,
+          abortSignal: opts.abortSignal,
         });
         scaffoldkit = { invoked: true, exitCode, stderr };
       } catch (err) {

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -61,9 +61,16 @@ api.use("*", async (c, next) => {
 // POST /api/generate — runs the planforge CLI in an isolated tempdir and
 // streams progress via SSE. Response content-type is text/event-stream.
 //
+// Request body: { input: <planning-input>, scaffold?: boolean }
+//   - `scaffold` (default true): after the CLI writes scaffoldkit-input.json,
+//     invoke scaffoldkit against the outdir so the `done` tarball contains
+//     scaffolded project files. Set `false` for planning-only runs.
+//
 // Events emitted:
 //   - `progress` — { requestId, stream: "stdout"|"stderr", line }
-//   - `done`     — { requestId, planOutput, scaffoldkitInput | null, exitCode: 0 }
+//   - `done`     — { requestId, planOutput, scaffoldkitInput | null,
+//                     scaffoldkit: { invoked, exitCode?, stderr?, skipped? },
+//                     outputTarGz, exitCode: 0 }
 //   - `error`    — { requestId, message, exitCode? }
 //
 // The CLI's stdout lines are the authoritative progress feed today; when the
@@ -78,7 +85,7 @@ api.post("/generate", async (c) => {
   }
   if (!body || typeof body !== "object" || !("input" in body)) {
     return c.json(
-      { error: "bad_request", message: "Body must be { input: <planning-input>, options?: {} }" },
+      { error: "bad_request", message: "Body must be { input: <planning-input>, scaffold?: boolean }" },
       400,
     );
   }
@@ -87,6 +94,9 @@ api.post("/generate", async (c) => {
   // become secrets downstream. Only the request id + timing + outcome are
   // log-worthy. See ADR-0002 § "Secret handling".
   const input = (body as { input: unknown }).input;
+  // Default scaffold=true. An explicit `false` opts out; any other value
+  // (including omission) preserves back-compat by scaffolding on.
+  const scaffold = (body as { scaffold?: unknown }).scaffold !== false;
 
   // Wire the HTTP client's AbortSignal through to the CLI subprocess so a
   // mid-stream disconnect doesn't leave an orphan node process + tempdir
@@ -103,6 +113,8 @@ api.post("/generate", async (c) => {
       for await (const ev of runGenerate(input, {
         planforgeRoot: env.PLANFORGE_ROOT,
         nodeBin: env.NODE_BIN,
+        scaffoldkitPython: env.SCAFFOLDKIT_PYTHON,
+        scaffold,
         abortSignal: controller.signal,
       })) {
         requestId = ev.requestId;

--- a/server/tests/routes.test.ts
+++ b/server/tests/routes.test.ts
@@ -450,6 +450,85 @@ describe("POST /api/generate — scaffoldkit", () => {
   );
 
   it(
+    "bundles files written by scaffoldkit into the response tarball",
+    async () => {
+      // Stub "python" = shell script that pretends to be scaffoldkit:
+      // walks argv for `--target`, writes a sentinel file there, exits 0.
+      // Proves the invoked→files-land-in-tarball pipeline end-to-end
+      // without needing the real Python venv.
+      const orig = env.SCAFFOLDKIT_PYTHON;
+      const { mkdtemp, writeFile, chmod, rm } = await import("node:fs/promises");
+      const { tmpdir } = await import("node:os");
+      const { resolve } = await import("node:path");
+      const stubDir = await mkdtemp(resolve(tmpdir(), "scaffoldkit-stub-ok-"));
+      const stub = resolve(stubDir, "python3");
+      await writeFile(
+        stub,
+        `#!/bin/sh
+# Walk argv for --target <dir>
+while [ $# -gt 0 ]; do
+  if [ "$1" = "--target" ]; then TARGET="$2"; break; fi
+  shift
+done
+if [ -z "$TARGET" ]; then echo "stub: --target not found" >&2; exit 2; fi
+mkdir -p "$TARGET"
+echo "hello from scaffoldkit stub" > "$TARGET/stub-scaffolded.txt"
+exit 0
+`,
+        { mode: 0o755 },
+      );
+      await chmod(stub, 0o755);
+      env.SCAFFOLDKIT_PYTHON = stub;
+      try {
+        const res = await app.fetch(
+          new Request("http://test/api/generate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: AUTH },
+            body: JSON.stringify({ input: sampleInput }),
+          }),
+        );
+        expect(res.status).toBe(200);
+        const events = await collectSSE(res.body);
+        const done = events.find((e) => e.event === "done")!.data as {
+          scaffoldkit: { invoked: boolean; exitCode?: number };
+          outputTarGz?: string;
+        };
+        expect(done.scaffoldkit.invoked).toBe(true);
+        expect(done.scaffoldkit.exitCode).toBe(0);
+        expect(typeof done.outputTarGz).toBe("string");
+
+        // Unpack the tarball and assert the stub's file is in it — proof
+        // the scaffold step ran AND its output was bundled.
+        const { spawn } = await import("node:child_process");
+        const { readdir } = await import("node:fs/promises");
+        const untarDir = await mkdtemp(resolve(tmpdir(), "planforge-untar-"));
+        try {
+          await new Promise<void>((resP, rejP) => {
+            const child = spawn("tar", ["-xzf", "-", "-C", untarDir], {
+              stdio: ["pipe", "ignore", "pipe"],
+            });
+            child.on("error", rejP);
+            child.on("close", (code) =>
+              code === 0 ? resP() : rejP(new Error(`tar ${code}`)),
+            );
+            child.stdin.end(Buffer.from(done.outputTarGz!, "base64"));
+          });
+          const top = await readdir(untarDir);
+          expect(top).toContain("stub-scaffolded.txt");
+          // Planning sentinel still present — scaffoldkit did not wipe.
+          expect(top).toContain("planforge-index.json");
+        } finally {
+          await rm(untarDir, { recursive: true, force: true });
+        }
+      } finally {
+        env.SCAFFOLDKIT_PYTHON = orig;
+        await rm(stubDir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  it(
     "reports `opt_out` when the caller passes scaffold:false",
     async () => {
       const res = await app.fetch(

--- a/server/tests/routes.test.ts
+++ b/server/tests/routes.test.ts
@@ -15,6 +15,13 @@ import { env } from "../src/config.js";
 const AUTH = `Bearer ${env.PLANFORGE_SERVICE_TOKEN}`;
 const SAMPLE_INPUT_PATH = resolve(env.PLANFORGE_ROOT, "examples", "sample-input.json");
 
+// Existing happy-path tests don't care about scaffolding — setting
+// `scaffold: false` keeps the server off the (test-env-dependent)
+// scaffoldkit binary. A dedicated describe block below covers the
+// scaffold:true paths explicitly.
+const GENERATE_BODY = (input: unknown, extra: Record<string, unknown> = {}) =>
+  JSON.stringify({ input, scaffold: false, ...extra });
+
 describe("GET /healthz", () => {
   it("is unauth and returns status ok", async () => {
     const res = await app.fetch(new Request("http://test/healthz"));
@@ -142,7 +149,7 @@ describe("POST /api/generate — happy path", () => {
         new Request("http://test/api/generate", {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: AUTH },
-          body: JSON.stringify({ input: sampleInput }),
+          body: GENERATE_BODY(sampleInput),
         }),
       );
       expect(res.status).toBe(200);
@@ -154,12 +161,21 @@ describe("POST /api/generate — happy path", () => {
       expect(types).not.toContain("error");
 
       const done = events.find((e) => e.event === "done")!
-        .data as { planOutput: { summary?: unknown }; scaffoldkitInput: unknown; exitCode: number };
+        .data as {
+          planOutput: { summary?: unknown };
+          scaffoldkitInput: unknown;
+          scaffoldkit: { invoked: boolean; skipped?: string };
+          exitCode: number;
+        };
       expect(done.exitCode).toBe(0);
       expect(done.planOutput).toBeTruthy();
       // The CLI always produces scaffoldkit-input.json on success for this sample
       // — assert it's non-null so a regression that stops writing it is caught.
       expect(done.scaffoldkitInput).toBeTruthy();
+      // scaffold: false was passed — scaffoldkit must have been skipped
+      // with that reason, not silently invoked.
+      expect(done.scaffoldkit.invoked).toBe(false);
+      expect(done.scaffoldkit.skipped).toBe("opt_out");
     },
     // CLI can take a few seconds on the sample input; give generous headroom.
     60_000,
@@ -173,14 +189,14 @@ describe("POST /api/generate — happy path", () => {
           new Request("http://test/api/generate", {
             method: "POST",
             headers: { "Content-Type": "application/json", Authorization: AUTH },
-            body: JSON.stringify({ input: sampleInput }),
+            body: GENERATE_BODY(sampleInput),
           }),
         ),
         app.fetch(
           new Request("http://test/api/generate", {
             method: "POST",
             headers: { "Content-Type": "application/json", Authorization: AUTH },
-            body: JSON.stringify({ input: sampleInput }),
+            body: GENERATE_BODY(sampleInput),
           }),
         ),
       ]);
@@ -221,7 +237,7 @@ describe("POST /api/generate — happy path", () => {
         new Request("http://test/api/generate", {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: AUTH },
-          body: JSON.stringify({ input: sampleInput }),
+          body: GENERATE_BODY(sampleInput),
         }),
       );
       expect(res.status).toBe(200);
@@ -297,7 +313,7 @@ describe("POST /api/generate — happy path", () => {
           new Request("http://test/api/generate", {
             method: "POST",
             headers: { "Content-Type": "application/json", Authorization: AUTH },
-            body: JSON.stringify({ input }),
+            body: GENERATE_BODY(input),
           }),
         );
         // Drain the SSE body so any subprocess-triggered logging has a
@@ -309,6 +325,147 @@ describe("POST /api/generate — happy path", () => {
       }
       const joined = captured.join("\n");
       expect(joined).not.toContain(sentinel);
+    },
+    60_000,
+  );
+});
+
+describe("POST /api/generate — scaffoldkit", () => {
+  let sampleInput: unknown;
+
+  beforeAll(async () => {
+    sampleInput = JSON.parse(await readFile(SAMPLE_INPUT_PATH, "utf8"));
+  });
+
+  async function collectSSE(body: ReadableStream<Uint8Array> | null) {
+    const events: Array<{ event: string; data: unknown }> = [];
+    if (!body) return events;
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let frameEnd: number;
+      while ((frameEnd = buf.indexOf("\n\n")) >= 0) {
+        const frame = buf.slice(0, frameEnd);
+        buf = buf.slice(frameEnd + 2);
+        const lines = frame.split("\n");
+        let event = "message";
+        let data = "";
+        for (const ln of lines) {
+          if (ln.startsWith("event:")) event = ln.slice(6).trim();
+          else if (ln.startsWith("data:")) data += ln.slice(5).trim();
+        }
+        if (data.length > 0) events.push({ event, data: JSON.parse(data) });
+      }
+    }
+    return events;
+  }
+
+  /**
+   * Drive the service through the scaffold-invoke path without needing
+   * the real scaffoldkit venv installed. We override SCAFFOLDKIT_PYTHON
+   * on the env before import-time caching by mutating `env.SCAFFOLDKIT_PYTHON`
+   * directly — the server reads it each generate via the `runGenerate`
+   * options, not a closure.
+   */
+  it(
+    "reports `not_installed` when SCAFFOLDKIT_PYTHON does not exist and scaffold defaults on",
+    async () => {
+      const orig = env.SCAFFOLDKIT_PYTHON;
+      env.SCAFFOLDKIT_PYTHON = "/definitely/does/not/exist/python3";
+      try {
+        const res = await app.fetch(
+          new Request("http://test/api/generate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: AUTH },
+            body: JSON.stringify({ input: sampleInput }),
+          }),
+        );
+        expect(res.status).toBe(200);
+        const events = await collectSSE(res.body);
+        expect(events.map((e) => e.event)).not.toContain("error");
+        const done = events.find((e) => e.event === "done")!.data as {
+          scaffoldkit: { invoked: boolean; skipped?: string };
+        };
+        expect(done.scaffoldkit.invoked).toBe(false);
+        expect(done.scaffoldkit.skipped).toBe("not_installed");
+      } finally {
+        env.SCAFFOLDKIT_PYTHON = orig;
+      }
+    },
+    60_000,
+  );
+
+  it(
+    "surfaces scaffoldkit's exit code + stderr in the `done` event when invoked",
+    async () => {
+      // Stub "python" = /bin/sh invoking a script that echoes to stderr
+      // and exits nonzero. Exercises the invoke→capture→surface path
+      // without requiring the real venv.
+      const orig = env.SCAFFOLDKIT_PYTHON;
+      // /bin/sh exits 2 and prints to stderr when given `-c 'echo x >&2; exit 2' ...`,
+      // but we can't pass args through our code path — we spawn with a
+      // fixed argv shape. Instead, use a stub shell script on disk:
+      const { mkdtemp, writeFile, chmod } = await import("node:fs/promises");
+      const { tmpdir } = await import("node:os");
+      const { resolve } = await import("node:path");
+      const stubDir = await mkdtemp(resolve(tmpdir(), "scaffoldkit-stub-"));
+      const stub = resolve(stubDir, "python3");
+      await writeFile(
+        stub,
+        "#!/bin/sh\necho 'stub-scaffoldkit: simulated failure' >&2\nexit 7\n",
+        { mode: 0o755 },
+      );
+      await chmod(stub, 0o755);
+      env.SCAFFOLDKIT_PYTHON = stub;
+      try {
+        const res = await app.fetch(
+          new Request("http://test/api/generate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: AUTH },
+            body: JSON.stringify({ input: sampleInput }),
+          }),
+        );
+        expect(res.status).toBe(200);
+        const events = await collectSSE(res.body);
+        expect(events.map((e) => e.event)).not.toContain("error");
+        const done = events.find((e) => e.event === "done")!.data as {
+          scaffoldkit: { invoked: boolean; exitCode?: number; stderr?: string };
+        };
+        // Nonzero scaffoldkit exit must NOT fail the whole request —
+        // planning succeeded, that's what the `done` event signals.
+        expect(done.scaffoldkit.invoked).toBe(true);
+        expect(done.scaffoldkit.exitCode).toBe(7);
+        expect(done.scaffoldkit.stderr).toContain("stub-scaffoldkit: simulated failure");
+      } finally {
+        env.SCAFFOLDKIT_PYTHON = orig;
+        const { rm } = await import("node:fs/promises");
+        await rm(stubDir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  it(
+    "reports `opt_out` when the caller passes scaffold:false",
+    async () => {
+      const res = await app.fetch(
+        new Request("http://test/api/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: AUTH },
+          body: JSON.stringify({ input: sampleInput, scaffold: false }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const events = await collectSSE(res.body);
+      const done = events.find((e) => e.event === "done")!.data as {
+        scaffoldkit: { invoked: boolean; skipped?: string };
+      };
+      expect(done.scaffoldkit.invoked).toBe(false);
+      expect(done.scaffoldkit.skipped).toBe("opt_out");
     },
     60_000,
   );


### PR DESCRIPTION
## Summary

Moves scaffoldkit invocation from project-forge into the agent-planforge HTTP service. Response tarball now contains both planning artifacts and scaffolded files, keyed by a new `scaffold` opt-in flag (default `true`) and a structured `scaffoldkit` field on the `done` event.

## Contract

`POST /api/generate` body accepts `{ input, scaffold?: boolean }`. On `done`:

```
{
  planOutput, scaffoldkitInput,
  scaffoldkit: { invoked, exitCode?, stderr?, skipped? },
  outputTarGz, exitCode: 0
}
```

Four branches on `scaffoldkit`:
- `{ invoked: true, exitCode: 0 }` — scaffold ran cleanly
- `{ invoked: true, exitCode: nonzero, stderr }` — ran but failed; planning artifacts are still returned, caller decides
- `{ invoked: false, skipped: "opt_out" | "no_input" | "not_installed" }` — intentional no-op

Nonzero scaffoldkit exit does NOT fail the whole request.

## Decisions

- **Tarball cap 10 MiB → 50 MiB.** Scaffolded trees are materially larger (a few MB gzipped is typical for a realistic blueprint). 50 MiB still refuses a pathological run, keeps ~10× headroom.
- **`scaffold` defaults to `true`.** That's what unblocks project-forge — it can rely on a scaffolded tarball from this service instead of running scaffoldkit locally.
- **Missing `SCAFFOLDKIT_PYTHON` → `skipped: "not_installed"`, not error.** Production containers always have the venv baked in; dev environments without it shouldn't get `error` events on unrelated work.
- **Nonzero exit surfaces as metadata, not error.** Mirrors project-forge's current "log-and-continue" behaviour, but gives the caller a structured signal instead of a silent log line.

## Test plan

- [x] `npm test` — 11 → 14 tests passing (3 new scaffoldkit cases: opt_out, not_installed, exit-code/stderr surfacing via a stub shell script)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] CI docker job — builds the image, drives a real `POST /api/generate`, asserts `scaffoldkit.invoked === true` AND the tarball contains both `planforge-index.json` and a top-level `README.md`. End-to-end proof the venv + blueprint + wiring are all intact.
- [ ] Reviewer sanity-checks the migration path for project-forge ticket `31e6f7db`.

Closes agent-tasks task `73c1f92d-04cd-40db-9c6c-576424ae7940`.
Unblocks agent-tasks task `31e6f7db-5422-4bbf-8862-6e642b6a6f9b` in project-forge.