### PR TITLE
fix(deploy): route panel deploys through project-forge planforge rebuild

### DIFF
--- a/.relay.yml
+++ b/.relay.yml
@@ -21,6 +21,19 @@ health_port: 8223
 # `/healthz` on port 8223 from inside it. Path is relative to APPS_DIR
 # (= /apps inside the relay container, = /root/git on the VPS host),
 # resolving to /apps/project-forge/docker-compose.yml.
+#
+# Side effect: agent-relay's preflight reports `containers_running` and
+# `traefik_labels` against PROJECT-FORGE's compose, not agent-planforge's.
+# Functionally correct (this deploy genuinely depends on project-forge
+# state being live) but worth knowing — a "preflight passed" line in
+# the deploy log is reading project-forge's runtime, not ours.
+#
+# Health-check semantics: relay iterates services in `docker compose ps`
+# order (app, planforge) and returns success on the FIRST container that
+# answers /healthz on port 8223. project-forge `app` listens on 3000 →
+# probe fails → relay falls through to planforge → planforge answers →
+# deploy reported green. If `app` ever exposes 8223 internally this
+# stops being a clear signal, but that change would itself be a red flag.
 compose_file: ../project-forge/docker-compose.yml
 
 command: |

--- a/.relay.yml
+++ b/.relay.yml
@@ -1,7 +1,37 @@
 name: agent-planforge
+
+# agent-planforge does not run as its own container — it lives as a service
+# inside project-forge's docker-compose (`build.context: ../agent-planforge`,
+# `dockerfile: server/Dockerfile`). "Deploy" via the panel therefore means
+# rebuild project-forge's planforge image with the latest agent-planforge
+# source and recreate just that one service.
+#
+# This routes through agent-relay's `command:` mode, which skips the
+# default-flow `compose build` (which would try to docker-compose-build a
+# Dockerfile and fail with `cli.named` parse errors). The command does the
+# git pull itself because customCommandDeploy doesn't auto-pull.
+
 # /healthz is unauth by design (Traefik + ops probe). The service-token
 # gate only guards /api/*.
 health: /healthz
 health_port: 8223
-compose_file: server/Dockerfile
-rollback: true
+
+# Pointed at project-forge's compose so the relay's post-command health
+# check can `docker compose ps` the planforge service container and probe
+# `/healthz` on port 8223 from inside it. Path is relative to APPS_DIR
+# (= /apps inside the relay container, = /root/git on the VPS host),
+# resolving to /apps/project-forge/docker-compose.yml.
+compose_file: ../project-forge/docker-compose.yml
+
+command: |
+  set -e
+  git pull --ff-only origin main
+  cd /apps/project-forge
+  docker compose build planforge
+  docker compose up -d planforge
+
+# Auto-rollback would `git reset --hard` agent-planforge to the pre-deploy
+# SHA but cannot undo project-forge's image rebuild + container recreate.
+# The rollback would be a lie. Operator intervention if a real rollback is
+# needed (revert + re-deploy).
+rollback: false


### PR DESCRIPTION
## Summary

Panel-triggered `deploy agent-planforge` was crashing every run with `yaml: unmarshal errors: line 32: cannot unmarshal !!str FROM no... into cli.named` because `.relay.yml` had `compose_file: server/Dockerfile` — a Dockerfile, not a compose file.

agent-planforge isn't deployed standalone; it lives as a service inside project-forge's docker-compose. So "deploy" really means "rebuild project-forge's planforge image with the latest agent-planforge source." This PR rewrites `.relay.yml` to route through agent-relay's `command:` mode and do exactly that.

## Diff

```diff
-compose_file: server/Dockerfile
-rollback: true
+compose_file: ../project-forge/docker-compose.yml
+command: |
+  set -e
+  git pull --ff-only origin main
+  cd /apps/project-forge
+  docker compose build planforge
+  docker compose up -d planforge
+rollback: false
```

- `command:` skips the broken default-flow `compose build`.
- `compose_file` points at project-forge's compose so the relay's post-command health probe can find the planforge service container and curl `http://planforge:8223/healthz` from inside.
- `rollback: false` because git-resetting agent-planforge wouldn't undo project-forge's image rebuild — the rollback would be a lie. Operator intervention if a real rollback is needed.

## Test plan

- [x] Manual rebuild via `docker compose build planforge && up -d planforge` (the same commands the new `command:` runs) verified earlier today during PR #62 dogfood — produced a healthy `project-forge-planforge-1` container with the scaffoldkit-enabled code, live `POST /api/generate` returned `scaffoldkit: {invoked: true, exitCode: 0}`.
- [ ] After merge: trigger panel deploy of agent-planforge. Expected: `command:` step succeeds, health check finds the planforge service container, `/healthz` returns 200, deploy marked successful.
- [ ] Confirm container still has the latest code: `docker exec project-forge-planforge-1 grep -c scaffoldkit /app/server/dist/generate.js > 0`.

Closes agent-tasks task `a26ac97a-b086-4e2d-b2e0-86021426fa46`.