### PR TITLE
feat(server): text-tier attachment ingest (v0.1b)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -56,6 +56,14 @@ Request:
   - Attachments are **not** forwarded to the CLI's `input.json` as a
     separate field; they stay in the service layer so the CLI schema
     stays stable across slices.
+  - **Side effect worth knowing**: `input.summary` is *also* regex-scanned
+    by the CLI for architecture heuristics (e.g. database-store inference
+    via phrases like `filesystem is the source of truth` or `no external
+    database` in `scripts/bootstrap-plan.js`). Attachment content
+    containing those phrases will influence those decisions. That's by
+    design — real architectural text SHOULD shape the plan — but clients
+    surfacing this upload in a UI should make it clear that attached
+    documents influence the generated plan beyond prompt interpolation.
 
 Response: `Content-Type: text/event-stream`. Events:
 

--- a/server/README.md
+++ b/server/README.md
@@ -40,12 +40,22 @@ Request:
   callers that scaffold separately, tests).
 - `attachments` — optional. Array of `{ name, mimeType, tier, inlineText?, contentRef? }`
   where `tier` is one of `text | diagram | structured`. Shape is validated
-  at the edge (400 on malformed entries). **v0.1a status: field accepted
-  but ignored** — the plan output is identical whether attachments are
-  sent or not. v0.1b will inject text-tier `inlineText` into the planning
-  prompt; later slices handle diagram and structured tiers. Attachments
-  are **not** forwarded to the CLI's `input.json`; they stay in the
-  service layer so the CLI schema remains stable across slices.
+  at the edge (400 `bad_request` on malformed entries).
+  - **Text tier** (`tier: "text"`, `inlineText` present): the service
+    prepends each entry as an "Additional context from attachment: &lt;name&gt;"
+    markdown block onto `input.summary` before invoking the CLI. The
+    augmented summary flows through every existing CLI prompt template
+    slot (clarify, architecture, intake) without schema changes.
+  - **Total-char cap**: sum of all text-tier `inlineText` lengths must
+    be ≤ 50,000 chars. Exceeding it returns 400 `attachments_too_large`.
+    Fail-fast by design — silent truncation risks dropping architecturally
+    important sections.
+  - **Diagram / structured tiers** are shape-validated but remain no-ops
+    at the prompt level until later slices (vision pass, drawio/puml
+    parsers).
+  - Attachments are **not** forwarded to the CLI's `input.json` as a
+    separate field; they stay in the service layer so the CLI schema
+    stays stable across slices.
 
 Response: `Content-Type: text/event-stream`. Events:
 

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -23,6 +23,20 @@ export interface Attachment {
 }
 
 /**
+ * Hard cap on total char length across all text-tier `inlineText` values
+ * in a single request. Chosen over summarization/chunking for v0.1b because
+ * silent truncation risks dropping architecturally important sections from
+ * an arc42 doc in ways the caller can't see. Fail-fast with 400 keeps the
+ * contract honest: oversize means "resample or split into smaller
+ * attachments", not "we quietly kept half of it".
+ *
+ * At ~4 chars/token this is ~12.5k tokens — well inside a planning-context
+ * budget for current-generation models and leaves headroom for the CLI's
+ * own prompt scaffolding (template, questionnaire, clarifications).
+ */
+export const ATTACHMENTS_MAX_TOTAL_CHARS = 50_000;
+
+/**
  * Edge-validation for the optional `attachments` field on POST /api/generate.
  * Returns `{ ok: true, attachments }` on a shape-valid payload (including the
  * "field absent" case, which yields `undefined`); returns `{ ok: false, message }`
@@ -72,6 +86,78 @@ function parseAttachments(
     });
   }
   return { ok: true, attachments: out };
+}
+
+/**
+ * v0.1b text-tier ingest. Builds the "Additional context" markdown block
+ * that gets prepended to `input.summary` before the CLI runs. Returns an
+ * empty string when there is nothing to inject (no attachments, none are
+ * text-tier, or none carry inlineText) — callers can test for `.length > 0`
+ * to decide whether to touch the input at all.
+ *
+ * Enforces the total-char cap across *all* text-tier `inlineText` entries
+ * combined (not per-entry) so a caller can't split a 500k arc42 doc across
+ * ten attachments and sneak past the guardrail.
+ *
+ * Diagram + structured tiers are intentionally ignored here. They're
+ * accepted by the shape validator, carried past v0.1b as no-ops, and will
+ * be wired up in later slices (vision pass, drawio/puml parsers).
+ */
+export function buildAdditionalContextBlock(
+  attachments: Attachment[] | undefined,
+): { ok: true; block: string } | { ok: false; message: string } {
+  if (!attachments || attachments.length === 0) return { ok: true, block: "" };
+  let totalChars = 0;
+  const parts: string[] = [];
+  for (const a of attachments) {
+    if (a.tier !== "text") continue;
+    if (typeof a.inlineText !== "string" || a.inlineText.length === 0) continue;
+    totalChars += a.inlineText.length;
+    if (totalChars > ATTACHMENTS_MAX_TOTAL_CHARS) {
+      return {
+        ok: false,
+        message: `attachments exceed the ${ATTACHMENTS_MAX_TOTAL_CHARS}-char total cap for text-tier inlineText; split or resample`,
+      };
+    }
+    // Use the per-attachment format the v0.1b spec agreed on. `---` is a
+    // markdown thematic break, which renders cleanly both in the raw
+    // prompt the CLI sees and in any downstream markdown-rendered view.
+    parts.push(`## Additional context from attachment: ${a.name}\n\n${a.inlineText}\n\n---`);
+  }
+  return { ok: true, block: parts.join("\n\n") };
+}
+
+/**
+ * Prepend the additional-context block onto `input.summary` (or seed
+ * summary with the block if the caller didn't supply one). Returns the
+ * same `input` reference when there's nothing to inject, so the hot path
+ * for callers without attachments stays allocation-free.
+ *
+ * Why mutate summary rather than adding a new input field (e.g.
+ * `input.additionalContext`):
+ *   - `summary` already flows into every relevant CLI prompt template
+ *     slot (`clarify-prompt-template.md:{{summary}}`, architecture prompt,
+ *     heuristic text-matchers at bootstrap-plan.js:1470).
+ *   - Adding a new input field would require touching the CLI's 4k-line
+ *     script AND every downstream template, inverting the v0.1a
+ *     "service layer owns attachment→input translation" commitment.
+ *   - Copy-on-write (spread into a new object) — never mutates the
+ *     caller's object.
+ */
+export function augmentInputWithContext(input: unknown, contextBlock: string): unknown {
+  if (contextBlock.length === 0) return input;
+  if (!input || typeof input !== "object") {
+    // Defensive fallback: if `input` isn't an object, we have no summary
+    // to prepend onto. Return a synthetic wrapper so the CLI still sees
+    // the attachment text; the CLI's input validator will surface any
+    // remaining shape problems with its usual error message.
+    return { summary: contextBlock };
+  }
+  const rec = input as Record<string, unknown>;
+  const originalSummary = typeof rec.summary === "string" ? rec.summary : "";
+  const combined =
+    originalSummary.length > 0 ? `${contextBlock}\n\n${originalSummary}` : contextBlock;
+  return { ...rec, summary: combined };
 }
 
 /**
@@ -169,18 +255,22 @@ api.post("/generate", async (c) => {
   // (including omission) preserves back-compat by scaffolding on.
   const scaffold = (body as { scaffold?: unknown }).scaffold !== false;
 
-  // v0.1a attachments contract: shape-validate at the edge, then drop.
-  // The field is part of the HTTP-service contract, NOT the CLI's input
-  // schema — it stays top-level on the request body. v0.1b will pre-process
-  // text-tier attachments into the planning prompt from here, still without
-  // changing input.json. Top-level placement keeps the CLI's schema stable
-  // across attachment slices and matches how `scaffold` sits.
+  // Attachments contract: shape-validate at the edge, then — for text-tier
+  // entries with inlineText — prepend the content as an "Additional context"
+  // block onto `input.summary` before writing input.json. The field itself
+  // stays top-level on the request body and is NOT forwarded into the CLI's
+  // input.json, so the CLI schema stays stable across attachment slices
+  // (matches how `scaffold` sits). Diagram + structured tiers are shape-
+  // validated but remain no-ops at the prompt level until later slices.
   const attachmentsParsed = parseAttachments((body as { attachments?: unknown }).attachments);
   if (!attachmentsParsed.ok) {
     return c.json({ error: "bad_request", message: attachmentsParsed.message }, 400);
   }
-  // attachments intentionally unused in v0.1a — field accepted, not forwarded.
-  void attachmentsParsed.attachments;
+  const contextBuild = buildAdditionalContextBlock(attachmentsParsed.attachments);
+  if (!contextBuild.ok) {
+    return c.json({ error: "attachments_too_large", message: contextBuild.message }, 400);
+  }
+  const augmentedInput = augmentInputWithContext(input, contextBuild.block);
 
   // Wire the HTTP client's AbortSignal through to the CLI subprocess so a
   // mid-stream disconnect doesn't leave an orphan node process + tempdir
@@ -194,7 +284,7 @@ api.post("/generate", async (c) => {
   return streamSSE(c, async (stream) => {
     let requestId: string | undefined;
     try {
-      for await (const ev of runGenerate(input, {
+      for await (const ev of runGenerate(augmentedInput, {
         planforgeRoot: env.PLANFORGE_ROOT,
         nodeBin: env.NODE_BIN,
         scaffoldkitPython: env.SCAFFOLDKIT_PYTHON,

--- a/server/tests/routes.test.ts
+++ b/server/tests/routes.test.ts
@@ -105,6 +105,132 @@ describe("POST /api/generate — auth", () => {
   });
 });
 
+describe("attachments helpers (unit — v0.1b text-tier ingest)", () => {
+  // Import via dynamic-inside-block so the test file still runs if these
+  // helpers get renamed in a future refactor — TS compile-time would catch
+  // it anyway, but static `import` here would break test discovery.
+  it("buildAdditionalContextBlock returns empty string for no attachments", async () => {
+    const { buildAdditionalContextBlock } = await import("../src/routes.js");
+    expect(buildAdditionalContextBlock(undefined)).toEqual({ ok: true, block: "" });
+    expect(buildAdditionalContextBlock([])).toEqual({ ok: true, block: "" });
+  });
+
+  it("buildAdditionalContextBlock skips diagram/structured tiers and attachments without inlineText", async () => {
+    const { buildAdditionalContextBlock } = await import("../src/routes.js");
+    const result = buildAdditionalContextBlock([
+      { name: "architecture.png", mimeType: "image/png", tier: "diagram" },
+      { name: "model.drawio", mimeType: "application/vnd.jgraph.mxfile", tier: "structured" },
+      { name: "empty.md", mimeType: "text/markdown", tier: "text", inlineText: "" },
+      { name: "notext.md", mimeType: "text/markdown", tier: "text" },
+    ]);
+    expect(result).toEqual({ ok: true, block: "" });
+  });
+
+  it("buildAdditionalContextBlock formats a single text-tier attachment", async () => {
+    const { buildAdditionalContextBlock } = await import("../src/routes.js");
+    const result = buildAdditionalContextBlock([
+      { name: "arc42.md", mimeType: "text/markdown", tier: "text", inlineText: "We use Postgres." },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.block).toBe(
+        "## Additional context from attachment: arc42.md\n\nWe use Postgres.\n\n---",
+      );
+    }
+  });
+
+  it("buildAdditionalContextBlock concatenates multiple text-tier attachments with double-newlines", async () => {
+    const { buildAdditionalContextBlock } = await import("../src/routes.js");
+    const result = buildAdditionalContextBlock([
+      { name: "a.md", mimeType: "text/markdown", tier: "text", inlineText: "alpha" },
+      { name: "b.md", mimeType: "text/markdown", tier: "text", inlineText: "beta" },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The "\n\n" separator between blocks means the `---` break from
+      // block A is followed by a blank line then block B's heading — a
+      // reader or LLM sees a clean section break, not two adjacent
+      // headings mashed together.
+      expect(result.block).toBe(
+        "## Additional context from attachment: a.md\n\nalpha\n\n---\n\n## Additional context from attachment: b.md\n\nbeta\n\n---",
+      );
+    }
+  });
+
+  it("buildAdditionalContextBlock rejects when total chars exceed the cap", async () => {
+    const { buildAdditionalContextBlock, ATTACHMENTS_MAX_TOTAL_CHARS } = await import(
+      "../src/routes.js"
+    );
+    const big = "x".repeat(ATTACHMENTS_MAX_TOTAL_CHARS + 1);
+    const result = buildAdditionalContextBlock([
+      { name: "huge.md", mimeType: "text/markdown", tier: "text", inlineText: big },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain(String(ATTACHMENTS_MAX_TOTAL_CHARS));
+      expect(result.message).toContain("split or resample");
+    }
+  });
+
+  it("buildAdditionalContextBlock rejects when summed chars across attachments exceed the cap", async () => {
+    const { buildAdditionalContextBlock, ATTACHMENTS_MAX_TOTAL_CHARS } = await import(
+      "../src/routes.js"
+    );
+    // Split one oversized payload across two attachments to prove the
+    // cap is applied to the SUM, not per-entry — otherwise a caller
+    // could bypass the limit by chunking client-side.
+    const half = "y".repeat(Math.ceil(ATTACHMENTS_MAX_TOTAL_CHARS / 2) + 1);
+    const result = buildAdditionalContextBlock([
+      { name: "a.md", mimeType: "text/markdown", tier: "text", inlineText: half },
+      { name: "b.md", mimeType: "text/markdown", tier: "text", inlineText: half },
+    ]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("augmentInputWithContext returns input unchanged when block is empty", async () => {
+    const { augmentInputWithContext } = await import("../src/routes.js");
+    const input = { summary: "original", projectName: "Test" };
+    const result = augmentInputWithContext(input, "");
+    // Same reference — hot path for no-attachments case stays allocation-free.
+    expect(result).toBe(input);
+  });
+
+  it("augmentInputWithContext prepends block onto existing summary, preserves other fields", async () => {
+    const { augmentInputWithContext } = await import("../src/routes.js");
+    const input = { summary: "original summary", projectName: "Test", extra: [1, 2] };
+    const result = augmentInputWithContext(input, "CONTEXT BLOCK") as Record<string, unknown>;
+    expect(result).not.toBe(input); // copy-on-write, not mutation
+    expect((input as Record<string, unknown>).summary).toBe("original summary"); // caller's object untouched
+    expect(result.summary).toBe("CONTEXT BLOCK\n\noriginal summary");
+    expect(result.projectName).toBe("Test");
+    expect(result.extra).toEqual([1, 2]);
+  });
+
+  it("augmentInputWithContext seeds summary when input had no summary string", async () => {
+    const { augmentInputWithContext } = await import("../src/routes.js");
+    const input = { projectName: "Test" };
+    const result = augmentInputWithContext(input, "CONTEXT BLOCK") as Record<string, unknown>;
+    expect(result.summary).toBe("CONTEXT BLOCK");
+    expect(result.projectName).toBe("Test");
+  });
+
+  it("augmentInputWithContext seeds summary when summary is a non-string (defensive)", async () => {
+    const { augmentInputWithContext } = await import("../src/routes.js");
+    const input = { summary: null };
+    const result = augmentInputWithContext(input, "CONTEXT") as Record<string, unknown>;
+    expect(result.summary).toBe("CONTEXT");
+  });
+
+  it("augmentInputWithContext wraps non-object input in a synthetic { summary } object", async () => {
+    const { augmentInputWithContext } = await import("../src/routes.js");
+    const result = augmentInputWithContext("I am a bare string", "CONTEXT") as Record<
+      string,
+      unknown
+    >;
+    expect(result).toEqual({ summary: "CONTEXT" });
+  });
+});
+
 describe("POST /api/generate — attachments validation (v0.1a contract stub)", () => {
   const MALFORMED_CASES: Array<{ label: string; attachments: unknown; expect: string }> = [
     { label: "non-array", attachments: "oops", expect: "must be an array" },
@@ -182,7 +308,7 @@ describe("POST /api/generate — attachments validation (v0.1a contract stub)", 
   }, 60_000);
 
   it(
-    "accepts a well-formed text-tier attachment and returns 200 with unchanged plan shape (v0.1a: field present but ignored)",
+    "accepts a well-formed text-tier attachment and streams to done (v0.1b: attachment augments prompt, still succeeds)",
     async () => {
       const sampleInput = JSON.parse(
         await readFile(SAMPLE_INPUT_PATH, "utf8"),
@@ -235,16 +361,48 @@ describe("POST /api/generate — attachments validation (v0.1a contract stub)", 
       expect(events.map((e) => e.event)).toContain("done");
       expect(events.map((e) => e.event)).not.toContain("error");
 
-      // v0.1a invariant: plan output carries no attachment trace yet.
-      // When v0.1b adds ingest, a new test will assert positive presence.
+      // v0.1b invariant: the prompt is augmented with the attachment text
+      // (unit tests above cover the string transformation deterministically).
+      // Here we only assert the CLI runs to completion through the augmented
+      // input; whether the LLM-free CLI surfaces the attachment content in
+      // plan-output is an LLM-layer smoke test, out of scope for unit runs.
       const done = events.find((e) => e.event === "done")!.data as {
         planOutput: Record<string, unknown>;
+        exitCode: number;
       };
-      const serialized = JSON.stringify(done.planOutput);
-      expect(serialized).not.toContain("arc42-snippet.md");
-      expect(serialized).not.toContain("Postgres for primary storage");
+      expect(done.exitCode).toBe(0);
+      expect(done.planOutput).toBeTruthy();
     },
     60_000,
+  );
+
+  it(
+    "rejects attachments whose total inlineText exceeds the char cap (400 attachments_too_large)",
+    async () => {
+      const { ATTACHMENTS_MAX_TOTAL_CHARS } = await import("../src/routes.js");
+      const overflow = "x".repeat(ATTACHMENTS_MAX_TOTAL_CHARS + 1);
+      const res = await app.fetch(
+        new Request("http://test/api/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: AUTH },
+          body: JSON.stringify({
+            input: {},
+            attachments: [
+              {
+                name: "huge.md",
+                mimeType: "text/markdown",
+                tier: "text",
+                inlineText: overflow,
+              },
+            ],
+          }),
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("attachments_too_large");
+      expect(body.message).toContain(String(ATTACHMENTS_MAX_TOTAL_CHARS));
+    },
   );
 });
 


### PR DESCRIPTION
## Summary

Slice 2 of 3 for the attachments feature. Builds on v0.1a (#64):

- For `tier: "text"` attachments with `inlineText`: concatenate into an "Additional context from attachment: &lt;name&gt;" markdown block and **prepend onto `input.summary`** before invoking the CLI.
- The CLI's existing prompt templates (clarify, architecture, intake) pick it up via `{{summary}}` slots — no CLI schema changes.
- **Guardrail**: sum of all text-tier `inlineText` lengths capped at 50,000 chars (≈12.5k tokens). Exceeding returns `400 attachments_too_large`. Fail-fast chosen over truncation to avoid silently dropping architecturally-important sections.
- Diagram + structured tiers remain shape-validated no-ops until later slices.
- Helpers `buildAdditionalContextBlock`, `augmentInputWithContext`, constant `ATTACHMENTS_MAX_TOTAL_CHARS` exported for unit testing.

## Documented side effect

`input.summary` is also regex-scanned by CLI heuristics (store inference etc. in `scripts/bootstrap-plan.js`). Prepending attachment text means architectural content can influence those decisions. By design — real architectural text SHOULD shape the plan — but the README now surfaces this explicitly for v0.1c UI authors.

## Design notes

Chose `input.summary` prepend over a new `input.additionalContext` field: summary already flows into every CLI prompt template slot; adding a new input field would require editing the 4k-line CLI + templates. Matches the v0.1a "service layer owns attachment→input translation" commitment.

## Follow-ups

- v0.1c (`f7d45ac9`, project-forge): minimal upload UI forwarding top-level `attachments`.
- Reviewer suggested an integration assertion reading the temp input.json to prove augmented summary reaches disk — filed as informal follow-up, not blocking.

## Test plan

- [x] `npm run build` clean
- [x] `PLANFORGE_SERVICE_TOKEN=test-token npm test -- --run` — 36/36 pass (12 new cases)
- [x] Rigorous review subagent: READY TO MERGE
- [x] README updated with side-effect note
- [ ] Post-deploy smoke: real arc42 fragment → plan references the attached architecture