### PR TITLE
feat(server): boot-guard for SCAFFOLDKIT_PYTHON + /healthz status

### DIFF
--- a/server/src/boot-guard.ts
+++ b/server/src/boot-guard.ts
@@ -1,0 +1,61 @@
+import { accessSync, constants } from "node:fs";
+import { env } from "./config.js";
+
+export type ScaffoldkitStatus = "ok" | "missing";
+
+let cachedStatus: ScaffoldkitStatus | undefined;
+let bootLogEmitted = false;
+
+function probe(): ScaffoldkitStatus {
+  try {
+    accessSync(env.SCAFFOLDKIT_PYTHON, constants.X_OK);
+    return "ok";
+  } catch {
+    return "missing";
+  }
+}
+
+/**
+ * Returns the SCAFFOLDKIT_PYTHON probe result, memoized for the lifetime
+ * of the process. Used by /healthz to surface deployment misconfig to the
+ * ops dashboard without re-stating the filesystem on every healthcheck.
+ */
+export function getScaffoldkitStatus(): ScaffoldkitStatus {
+  if (cachedStatus === undefined) cachedStatus = probe();
+  return cachedStatus;
+}
+
+/**
+ * Boot-time loud-warn when SCAFFOLDKIT_PYTHON is missing/non-executable.
+ * Without this guard a misconfigured deployment boots cleanly, then every
+ * /api/generate with scaffold:true (the default) returns
+ * `skipped: "not_installed"` silently — easy to miss in monitoring for
+ * hours. Idempotent: only logs on the first call.
+ *
+ * Not fatal: dev environments legitimately don't ship the venv. Set
+ * PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT=1 to acknowledge the dev case and
+ * downgrade the message to a single-line info note.
+ */
+export function reportScaffoldkitStatusOnBoot(): ScaffoldkitStatus {
+  const status = getScaffoldkitStatus();
+  if (bootLogEmitted) return status;
+  bootLogEmitted = true;
+  if (status === "ok") return status;
+  const allowMissing = process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT === "1";
+  if (allowMissing) {
+    console.warn(
+      `[boot] SCAFFOLDKIT_PYTHON ${env.SCAFFOLDKIT_PYTHON} is missing or not executable; ` +
+        `PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT=1 set, continuing (scaffold steps will skip).`,
+    );
+    return status;
+  }
+  console.warn(
+    "\n" +
+      "!!! [boot] SCAFFOLDKIT_PYTHON is missing or not executable.\n" +
+      `!!!       path: ${env.SCAFFOLDKIT_PYTHON}\n` +
+      "!!!       Every /api/generate with scaffold:true (the default) will return\n" +
+      '!!!       skipped: "not_installed" silently. Fix the deployment, or set\n' +
+      "!!!       PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT=1 to acknowledge this is a dev env.\n",
+  );
+  return status;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,9 @@
 import { serve } from "@hono/node-server";
 import { env } from "./config.js";
+import { reportScaffoldkitStatusOnBoot } from "./boot-guard.js";
 import { app } from "./routes.js";
+
+reportScaffoldkitStatusOnBoot();
 
 const server = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
   console.log(

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { timingSafeEqual } from "node:crypto";
 import { env } from "./config.js";
+import { getScaffoldkitStatus } from "./boot-guard.js";
 import { runGenerate } from "./generate.js";
 
 export const app = new Hono();
@@ -187,6 +188,12 @@ app.get("/healthz", (c) =>
     status: "ok",
     service: "agent-planforge",
     uptime: process.uptime(),
+    // Surface the SCAFFOLDKIT_PYTHON probe so the ops dashboard can flag a
+    // misconfigured deployment without having to inspect logs. "missing"
+    // does not flip `status` to non-ok — the service still answers /generate
+    // requests, scaffolding just silently skips. Treat this as a deployment-
+    // health indicator rather than a liveness signal.
+    scaffoldkitPython: getScaffoldkitStatus(),
   }),
 );
 

--- a/server/tests/boot-guard.test.ts
+++ b/server/tests/boot-guard.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the SCAFFOLDKIT_PYTHON boot guard. Each test resets the
+ * module graph so the boot-guard re-imports `env` against a freshly-set
+ * SCAFFOLDKIT_PYTHON. `process.execPath` is used as a known-executable
+ * stand-in for the venv on the local machine; a non-existent path under
+ * /tmp covers the "missing" case without depending on filesystem state.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const ORIGINAL_SCAFFOLDKIT_PYTHON = process.env.SCAFFOLDKIT_PYTHON;
+const ORIGINAL_ALLOW = process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT;
+const NON_EXISTENT_PATH = "/tmp/agent-planforge-boot-guard-nonexistent-binary";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  // Restore env so cross-suite leakage doesn't confuse other tests that
+  // import config.ts at top level.
+  if (ORIGINAL_SCAFFOLDKIT_PYTHON === undefined) {
+    delete process.env.SCAFFOLDKIT_PYTHON;
+  } else {
+    process.env.SCAFFOLDKIT_PYTHON = ORIGINAL_SCAFFOLDKIT_PYTHON;
+  }
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT;
+  } else {
+    process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT = ORIGINAL_ALLOW;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("boot-guard probe", () => {
+  it("returns 'ok' when SCAFFOLDKIT_PYTHON points at an executable", async () => {
+    process.env.SCAFFOLDKIT_PYTHON = process.execPath;
+    const { getScaffoldkitStatus } = await import("../src/boot-guard.js");
+    expect(getScaffoldkitStatus()).toBe("ok");
+  });
+
+  it("returns 'missing' when SCAFFOLDKIT_PYTHON path does not exist", async () => {
+    process.env.SCAFFOLDKIT_PYTHON = NON_EXISTENT_PATH;
+    const { getScaffoldkitStatus } = await import("../src/boot-guard.js");
+    expect(getScaffoldkitStatus()).toBe("missing");
+  });
+
+  it("memoizes the probe result across calls", async () => {
+    process.env.SCAFFOLDKIT_PYTHON = process.execPath;
+    const mod = await import("../src/boot-guard.js");
+    const first = mod.getScaffoldkitStatus();
+    const second = mod.getScaffoldkitStatus();
+    expect(first).toBe("ok");
+    expect(second).toBe("ok");
+    // No public probe-count to assert on; the cache invariant matters
+    // because /healthz hits this on every request.
+  });
+});
+
+describe("boot-guard reportScaffoldkitStatusOnBoot", () => {
+  it("does not log when SCAFFOLDKIT_PYTHON is healthy", async () => {
+    process.env.SCAFFOLDKIT_PYTHON = process.execPath;
+    delete process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { reportScaffoldkitStatusOnBoot } = await import("../src/boot-guard.js");
+    expect(reportScaffoldkitStatusOnBoot()).toBe("ok");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits a loud multi-line warning when missing without opt-in", async () => {
+    process.env.SCAFFOLDKIT_PYTHON = NON_EXISTENT_PATH;
+    delete process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { reportScaffoldkitStatusOnBoot } = await import("../src/boot-guard.js");
+    expect(reportScaffoldkitStatusOnBoot()).toBe("missing");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0]?.[0] as string;
+    expect(message).toContain("SCAFFOLDKIT_PYTHON");
+    expect(message).toContain(NON_EXISTENT_PATH);
+    // The loud variant explicitly names the silent-skip failure mode and
+    // the opt-in escape hatch — both required so an operator reading the
+    // log can act without grep-ing the codebase.
+    expect(message).toContain("not_installed");
+    expect(message).toContain("PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT=1");
+  });
+
+  it("emits a single mild line when missing with opt-in env", async () => {
+    process.env.SCAFFOLDKIT_PYTHON = NON_EXISTENT_PATH;
+    process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT = "1";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { reportScaffoldkitStatusOnBoot } = await import("../src/boot-guard.js");
+    expect(reportScaffoldkitStatusOnBoot()).toBe("missing");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0]?.[0] as string;
+    // Mild variant must NOT include the !!! banner — that's the visible
+    // distinction between "you forgot to set the env" and "I know, dev box".
+    expect(message).not.toContain("!!!");
+    expect(message).toContain("PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT=1");
+  });
+
+  it("only logs once even if called multiple times", async () => {
+    process.env.SCAFFOLDKIT_PYTHON = NON_EXISTENT_PATH;
+    delete process.env.PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { reportScaffoldkitStatusOnBoot } = await import("../src/boot-guard.js");
+    reportScaffoldkitStatusOnBoot();
+    reportScaffoldkitStatusOnBoot();
+    reportScaffoldkitStatusOnBoot();
+    // Idempotency matters because a future ops harness might want to
+    // re-check on SIGHUP without spamming the log on every signal.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/tests/routes.test.ts
+++ b/server/tests/routes.test.ts
@@ -26,9 +26,19 @@ describe("GET /healthz", () => {
   it("is unauth and returns status ok", async () => {
     const res = await app.fetch(new Request("http://test/healthz"));
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { status: string; service: string };
+    const body = (await res.json()) as {
+      status: string;
+      service: string;
+      scaffoldkitPython: string;
+    };
     expect(body.status).toBe("ok");
     expect(body.service).toBe("agent-planforge");
+    // The scaffoldkitPython probe is exposed so the ops dashboard can flag
+    // a misconfigured deployment. In the test env the default
+    // /opt/sk-venv/bin/python3 doesn't exist, so the field reports
+    // "missing"; production where the Dockerfile lays down the venv
+    // reports "ok".
+    expect(body.scaffoldkitPython).toBe("missing");
   });
 
   it("is reachable even without the bearer token", async () => {


### PR DESCRIPTION
Closes task `aa0502b3` (PR #62 review follow-up, MED).

## Problem

Without a probe at boot, a deployment that ships a misconfigured `SCAFFOLDKIT_PYTHON` (wrong path, missing venv, missing exec bit) starts cleanly and every `/api/generate` with `scaffold:true` (the default) returns `skipped: "not_installed"` silently. That can run for hours before the ops dashboard or a downstream consumer notices scaffolded outputs went missing.

## Fix

- New `server/src/boot-guard.ts`: memoized `accessSync(SCAFFOLDKIT_PYTHON, X_OK)` probe.
- `index.ts` calls `reportScaffoldkitStatusOnBoot()` once at startup. If the binary is missing/non-executable AND `PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT=1` is **not** set, emits a loud multi-line `console.warn` naming the path, the silent-skip failure mode, and the opt-in escape hatch. With the opt-in set, downgrades to a one-line note (dev escape hatch).
- `/healthz` exposes `scaffoldkitPython: "ok" | "missing"` so the ops dashboard can flag drift without log inspection. `status` stays `"ok"` regardless — the service is alive and the non-scaffold path still works; only the new field reflects degraded mode.

Not fatal — dev environments legitimately don't ship the venv.

## Tests (7 new + 1 updated)

- `boot-guard.test.ts`: probe ok/missing/memoization; loud-vs-mild log gating with assertions on the actual message content (path, failure-mode keyword `not_installed`, escape-hatch env var, banner presence/absence); idempotency (repeated calls → 1 warn).
- `routes.test.ts`: existing `/healthz` test now also asserts `scaffoldkitPython: "missing"` (deterministic in test env where the default `/opt/sk-venv/bin/python3` doesn't exist).

43/43 tests green; `tsc --noEmit` clean.

## Acceptance

- [x] Misconfigured `SCAFFOLDKIT_PYTHON` produces a single loud warning at boot.
- [x] `PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT=1` opts into a milder one-line warning.
- [x] Not fatal.
- [x] `/healthz` exposes the status as a stable string field.
- [x] Single warning even if `reportScaffoldkitStatusOnBoot` is called multiple times.

## Out of scope

- Re-probe on SIGHUP / file-watcher.
- Healthz-driven alert routing in the ops dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)