### PR TITLE
security: bump fast-uri / hono (CVE sweep 2026-05-10, 2 HIGH + 4 MED + 1 LOW)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-planforge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-planforge",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0"
@@ -38,9 +38,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-planforge/server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-planforge/server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "hono": "^4.7.9",
@@ -1129,9 +1129,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Closes agent-tasks `064b1246`. Part of the 2026-05-10 cross-repo CVE sweep.

`npm audit fix` minimal at root + `server/`. Lockfile-only diff.

Cleared:
- HIGH `fast-uri` CVE-2026-6321 / 6322 (root)
- MED `hono` CVE-2026-44455 / 56 / 57 / 58 (server/)
- LOW `hono` CVE-2026-44459 (server/)

Resolved: root fast-uri 3.1.2; server hono 4.12.18.

## Test plan

- [x] `npm audit` 0 vulns at root and in server/.
- [x] `npm test` 43/43 pass; server `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)