### PR TITLE
feat(server): distinguish scaffoldkit-input absent vs malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- HTTP server: `scaffoldkit.skipped` on the `done` event gains a fifth
+  value `"input_unreadable"` plus an optional `inputReadError?: string`
+  field. Previously every failure reading `exports/scaffoldkit-input.json`
+  (ENOENT, EACCES, malformed JSON) collapsed into `skipped: "no_input"`,
+  hiding a broken CLI behind a normal-path no-op. ENOENT still maps to
+  `"no_input"`; any other read or `JSON.parse` failure now reports
+  `"input_unreadable"` with the underlying error message in
+  `inputReadError`. The field is optional and additive — existing
+  consumers ignoring it are unaffected.
+
 ## [0.2.0] - 2026-04-24
 
 **Headline: The HTTP server gained a full scaffolding path and an

--- a/server/README.md
+++ b/server/README.md
@@ -69,7 +69,7 @@ Response: `Content-Type: text/event-stream`. Events:
 
 - `progress` — `{ requestId, stream: "stdout" | "stderr", line }` — one per
   CLI log line
-- `done` — `{ requestId, planOutput, scaffoldkitInput: <object> | null, scaffoldkit: { invoked, exitCode?, stderr?, skipped? }, outputTarGz: <base64 gzip tarball>, exitCode: 0 }`. The tarball packs the **contents** of the CLI's output dir (not a nested `out/` folder); untar with `tar -xzf - -C <targetDir>`. Hard cap: 50 MiB (gzipped) — raised from 10 MiB when scaffolding landed because a scaffolded project tree can be several MB. Large enough for typical runs and keeps a pathological prompt from streaming an unbounded blob into the client's memory.
+- `done` — `{ requestId, planOutput, scaffoldkitInput: <object> | null, scaffoldkit: { invoked, exitCode?, stderr?, skipped?, inputReadError? }, outputTarGz: <base64 gzip tarball>, exitCode: 0 }`. The tarball packs the **contents** of the CLI's output dir (not a nested `out/` folder); untar with `tar -xzf - -C <targetDir>`. Hard cap: 50 MiB (gzipped) — raised from 10 MiB when scaffolding landed because a scaffolded project tree can be several MB. Large enough for typical runs and keeps a pathological prompt from streaming an unbounded blob into the client's memory.
 - `error` — `{ requestId, message, exitCode? }`
 
 The `scaffoldkit` field on `done` always exists. Its `skipped` value
@@ -79,6 +79,7 @@ tells callers why scaffolding was not performed:
 | --- | --- |
 | `opt_out` | Caller passed `scaffold: false` |
 | `no_input` | CLI did not write `scaffoldkit-input.json` (not every input produces one) |
+| `input_unreadable` | `scaffoldkit-input.json` exists but read / `JSON.parse` failed — almost always a CLI bug. The underlying error message is in `inputReadError` so callers can distinguish a parse failure from a permission issue. |
 | `not_installed` | `SCAFFOLDKIT_PYTHON` is missing — dev env without the venv; production containers always have it |
 
 A nonzero `scaffoldkit.exitCode` does **not** fail the request — planning

--- a/server/src/generate.ts
+++ b/server/src/generate.ts
@@ -80,11 +80,20 @@ export interface ScaffoldkitResult {
   stderr?: string;
   /**
    * Reason scaffoldkit was not invoked.
-   * - `no_input`      — CLI didn't write scaffoldkit-input.json
-   * - `opt_out`       — caller passed `scaffold: false`
-   * - `not_installed` — SCAFFOLDKIT_PYTHON binary is missing (dev / tests)
+   * - `no_input`         — CLI didn't write scaffoldkit-input.json (ENOENT)
+   * - `input_unreadable` — file exists but JSON.parse / IO failed (CLI bug)
+   * - `opt_out`          — caller passed `scaffold: false`
+   * - `not_installed`    — SCAFFOLDKIT_PYTHON binary is missing (dev / tests)
    */
-  skipped?: "no_input" | "opt_out" | "not_installed";
+  skipped?: "no_input" | "input_unreadable" | "opt_out" | "not_installed";
+  /**
+   * Populated only when `skipped === "input_unreadable"`. Carries the
+   * underlying error message (e.g. `Unexpected token } in JSON at position 12`)
+   * so the caller can distinguish a JSON-parse bug from a permission-denied
+   * read. The full path is intentionally omitted — it lives in the server's
+   * tempdir, not anything the caller can act on.
+   */
+  inputReadError?: string;
 }
 
 /**
@@ -412,11 +421,19 @@ export async function* runGenerate(
       return;
     }
     const scaffoldkitInputPath = resolve(outdir, "exports", "scaffoldkit-input.json");
+    // Distinguish "file does not exist" (common — not every planning input
+    // produces a scaffoldkit input) from "file exists but is unreadable /
+    // malformed" (rare — almost certainly a CLI bug). The first case is
+    // a normal skip; the second is diagnostic information the caller wants
+    // surfaced so a silently broken CLI doesn't masquerade as no-op.
+    let scaffoldkitInputReadError: string | null = null;
     try {
       scaffoldkitInput = JSON.parse(await readFile(scaffoldkitInputPath, "utf8"));
-    } catch {
-      // scaffoldkit-input.json is optional — not every input produces one.
+    } catch (err) {
       scaffoldkitInput = null;
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        scaffoldkitInputReadError = (err as Error).message;
+      }
     }
 
     // Run scaffoldkit if the CLI produced an input and the caller didn't
@@ -425,6 +442,12 @@ export async function* runGenerate(
     let scaffoldkit: ScaffoldkitResult;
     if (!opts.scaffold) {
       scaffoldkit = { invoked: false, skipped: "opt_out" };
+    } else if (scaffoldkitInputReadError !== null) {
+      scaffoldkit = {
+        invoked: false,
+        skipped: "input_unreadable",
+        inputReadError: scaffoldkitInputReadError,
+      };
     } else if (scaffoldkitInput === null) {
       scaffoldkit = { invoked: false, skipped: "no_input" };
     } else {

--- a/server/src/generate.ts
+++ b/server/src/generate.ts
@@ -68,11 +68,11 @@ export interface GenerateOptions {
 
 /**
  * Describes what happened with scaffoldkit for a given generate run.
- * Always present on the `done` event so callers can tell the four cases
+ * Always present on the `done` event so callers can tell the cases
  * apart without second-guessing:
  *   - `invoked: true, exitCode: 0`       — scaffolding ran cleanly
  *   - `invoked: true, exitCode: nonzero` — ran but failed; planning OK
- *   - `invoked: false, skipped: "…"`     — intentionally not run
+ *   - `invoked: false, skipped: "…"`     — not run; see `skipped` field
  */
 export interface ScaffoldkitResult {
   invoked: boolean;

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -230,7 +230,7 @@ api.use("*", async (c, next) => {
 // Events emitted:
 //   - `progress` — { requestId, stream: "stdout"|"stderr", line }
 //   - `done`     — { requestId, planOutput, scaffoldkitInput | null,
-//                     scaffoldkit: { invoked, exitCode?, stderr?, skipped? },
+//                     scaffoldkit: { invoked, exitCode?, stderr?, skipped?, inputReadError? },
 //                     outputTarGz, exitCode: 0 }
 //   - `error`    — { requestId, message, exitCode? }
 //

--- a/server/tests/routes.test.ts
+++ b/server/tests/routes.test.ts
@@ -890,11 +890,21 @@ describe("runGenerate — guard rails (PR #62 follow-up)", () => {
    */
   async function setupStubCli(opts: {
     writeScaffoldInput: boolean;
+    /**
+     * When provided, the stub writes this exact byte sequence as the
+     * contents of `exports/scaffoldkit-input.json` instead of valid JSON.
+     * Implies the parent directory is created (i.e. as if
+     * `writeScaffoldInput: true` was set), but the content bypasses
+     * JSON.stringify so a malformed payload like `{not json` reaches
+     * the JSON.parse error path.
+     */
+    rawScaffoldInputBody?: string;
     extraBytes?: number;
   }): Promise<{ planforgeRoot: string; cleanup: () => Promise<void> }> {
     const root = await mkdtemp(resolve(tmpdir(), "planforge-stub-cli-"));
     const scriptDir = resolve(root, "scripts");
     await mkdir(scriptDir, { recursive: true });
+    const writeMalformed = typeof opts.rawScaffoldInputBody === "string";
     const script = `#!/usr/bin/env node
 const fs = require("node:fs");
 const path = require("node:path");
@@ -917,6 +927,16 @@ ${
 fs.writeFileSync(
   path.join(outdir, "exports", "scaffoldkit-input.json"),
   JSON.stringify({ stub: true }),
+);
+`
+    : ""
+}
+${
+  writeMalformed
+    ? `fs.mkdirSync(path.join(outdir, "exports"), { recursive: true });
+fs.writeFileSync(
+  path.join(outdir, "exports", "scaffoldkit-input.json"),
+  ${JSON.stringify(opts.rawScaffoldInputBody)},
 );
 `
     : ""
@@ -975,6 +995,53 @@ process.exit(0);
         expect(done.scaffoldkit?.skipped).toBe("no_input");
         // scaffoldkitInput is the field that drove the branch; surface it
         // so a regression in the JSON.parse / ENOENT split is visible.
+        expect(done.scaffoldkitInput).toBeNull();
+        // The no_input branch must NOT carry a parse error — that's the
+        // diagnostic-bearing sibling branch (`input_unreadable`).
+        expect(done.scaffoldkit?.inputReadError).toBeUndefined();
+      } finally {
+        await stub.cleanup();
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "reports `skipped: input_unreadable` with the parse error when scaffoldkit-input.json is malformed",
+    async () => {
+      // Distinguish "file absent" (skipped: no_input) from "file present
+      // but unreadable" (skipped: input_unreadable). The second is the
+      // diagnostic case — a silent CLI bug that previously collapsed into
+      // the same no-op branch as a normal missing file.
+      const stub = await setupStubCli({
+        writeScaffoldInput: false,
+        rawScaffoldInputBody: "{not valid json",
+      });
+      try {
+        const events = await drain(
+          runGenerate(
+            {},
+            {
+              planforgeRoot: stub.planforgeRoot,
+              nodeBin: process.execPath,
+              scaffoldkitPython: process.execPath,
+              scaffold: true,
+            },
+          ),
+        );
+        expect(events.map((e) => e.type)).not.toContain("error");
+        const done = events.find((e) => e.type === "done")!;
+        expect(done.scaffoldkit?.invoked).toBe(false);
+        expect(done.scaffoldkit?.skipped).toBe("input_unreadable");
+        expect(done.scaffoldkit?.inputReadError).toBeDefined();
+        // Loose match — the exact JSON.parse phrasing varies by Node
+        // version. Both pre-22 ("Unexpected token") and 22+ ("Expected
+        // property name") wording mention JSON or the offending token.
+        expect(done.scaffoldkit?.inputReadError).toMatch(/JSON|token|property/i);
+        // The file existed, so the planning artifact still rides through
+        // and scaffoldkitInput stays null (parse failed). Surface both
+        // so a regression that, e.g., starts re-treating malformed as
+        // valid surfaces immediately.
         expect(done.scaffoldkitInput).toBeNull();
       } finally {
         await stub.cleanup();


### PR DESCRIPTION
## Summary

Splits a previously-conflated catch in `server/src/generate.ts`:

Before, every read failure on `exports/scaffoldkit-input.json` (ENOENT, EACCES, malformed JSON, …) hit a bare `catch {}`, set `scaffoldkitInput = null`, and downstream reported `skipped: "no_input"`. The common case (file just not produced) and the diagnostic case (CLI bug producing unreadable output) collapsed into one signal, silently hiding a broken CLI.

After:

- The catch splits on `(err as NodeJS.ErrnoException).code === "ENOENT"`. ENOENT keeps the existing `no_input` behaviour; everything else records the error message and drives a new branch.
- `ScaffoldkitResult.skipped` gains `"input_unreadable"`; a new optional `inputReadError?: string` field carries the underlying parser / IO message so callers can distinguish a JSON-parse bug from a permission issue. Full path intentionally omitted (server-tempdir-local, nothing the caller can act on).
- Branch order in the skipped cascade puts `input_unreadable` ahead of `no_input` so a malformed file always wins.

Docs updated to match: `server/README.md` skipped-table + `done`-shape, `server/src/routes.ts` SSE-shape comment, `CHANGELOG.md` `[Unreleased]` entry.

## Test plan

- [x] New regression test stubs `bootstrap-plan.js` with `{not valid json` content; asserts `skipped: input_unreadable`, `inputReadError` matches `/JSON|token|property/i` (covers Node 20/22 JSON.parse phrasing drift), `scaffoldkitInput` stays null.
- [x] Existing `no_input` test gains a guard that `inputReadError` is undefined for the ENOENT path, so the two branches stay deterministically distinct.
- [x] `npm test` 47/47 vitest green (46 prior + 1 new)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `git diff main -- server/src/routes.ts` empty before doc commit (route layer untouched)
- [x] Cross-repo type-drift on `project-forge/lib/planforge-client.ts:53-58` filed as follow-up task `523fad4c` (additive, no runtime bug today; `assertScaffoldkitRan` passes unknown strings through verbatim).

## Review

Rigorous review subagent verdict: `APPROVE_WITH_NITS`. No blocking findings. Three in-repo doc nits (README skipped-table, routes.ts SSE comment, CHANGELOG) fixed inline in commit `8763bc9`. Cross-repo nit (project-forge mirror type) scope-out as follow-up.
