### PR TITLE
refactor(output-layout): relocate planning docs to .planforge/docs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `inputReadError`. The field is optional and additive — existing
   consumers ignoring it are unaffected.
 
+### Changed
+
+- Output layout: the four planning prose docs (`project-charter.md`,
+  `architecture-overview.md`, `delivery-plan.md`,
+  `intake-questionnaire.md`) now generate under `.planforge/docs/` instead
+  of the project root, reducing root clutter. `planforge-index.json`
+  `rootFiles` entries point at the new locations and the index gains a
+  `directories.docs` entry, so index-honoring consumers follow the move
+  with no change. The index schema and `version` are unchanged. `AGENTS.md`,
+  `CLAUDE.md`, `PROJECT.md`, and `planforge-index.json` stay at the root.
+  `analyze-artifacts` resolves the docs from the new location and still
+  reads legacy root-level outputs. First step of a phased output-layout
+  redesign; see `docs/output-layout-migration.md`.
+
 ## [0.2.0] - 2026-04-24
 
 **Headline: The HTTP server gained a full scaffolding path and an

--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ This creates:
 - `out/sample/planning/plan-output.json`
 - `out/sample/planning/structured-input.json`
 - `out/sample/PROJECT.md`
-- `out/sample/intake-questionnaire.md`
-- `out/sample/project-charter.md`
-- `out/sample/architecture-overview.md`
-- `out/sample/delivery-plan.md`
+- `out/sample/.planforge/docs/intake-questionnaire.md`
+- `out/sample/.planforge/docs/project-charter.md`
+- `out/sample/.planforge/docs/architecture-overview.md`
+- `out/sample/.planforge/docs/delivery-plan.md`
 - `out/sample/handoff/runner-contract.json`
 - `out/sample/planning/rerun-report.json`
 - `out/sample/planning/rerun-summary.md`

--- a/config/planner-config.json
+++ b/config/planner-config.json
@@ -35,8 +35,8 @@
       ]
     },
     "artifactsBase": [
-      "project-charter.md",
-      "architecture-overview.md",
+      ".planforge/docs/project-charter.md",
+      ".planforge/docs/architecture-overview.md",
       "adrs/",
       "tasks/"
     ],

--- a/docs/operational-workflow.md
+++ b/docs/operational-workflow.md
@@ -29,9 +29,9 @@ After each run, review these files first:
 - `planforge-index.json`
 - `planning/structured-input.json`
 - `planning/plan-output.json`
-- `project-charter.md`
-- `architecture-overview.md`
-- `delivery-plan.md`
+- `.planforge/docs/project-charter.md`
+- `.planforge/docs/architecture-overview.md`
+- `.planforge/docs/delivery-plan.md`
 - `planning/rerun-summary.md`
 
 If the input was parsed from text or markdown, check `planning/structured-input.json` before trusting the backlog.

--- a/docs/output-layout-migration.md
+++ b/docs/output-layout-migration.md
@@ -10,14 +10,12 @@ The current layout keeps the root focused on human and agent entry points:
 - `CLAUDE.md`
 - `planforge-index.json`
 - `PROJECT.md`
-- `project-charter.md`
-- `architecture-overview.md`
-- `delivery-plan.md`
 
-Machine-oriented artifacts now live in grouped directories.
+Planning prose and machine-oriented artifacts now live in grouped directories.
 
 ## New Layout
 
+- `.planforge/docs/` for planning prose (charter, architecture overview, delivery plan, intake questionnaire)
 - `planning/` for planning state and rerun metadata
 - `handoff/` for orchestration and runner state
 - `exports/` for downstream tool exports
@@ -36,6 +34,10 @@ Machine-oriented artifacts now live in grouped directories.
 | `runner/` | `handoff/runner/` |
 | `scaffoldkit-input.json` | `exports/scaffoldkit-input.json` |
 | `.devreview.json` | `exports/devreview.json` |
+| `project-charter.md` | `.planforge/docs/project-charter.md` |
+| `architecture-overview.md` | `.planforge/docs/architecture-overview.md` |
+| `delivery-plan.md` | `.planforge/docs/delivery-plan.md` |
+| `intake-questionnaire.md` | `.planforge/docs/intake-questionnaire.md` |
 
 ## Compatibility Notes
 

--- a/docs/scaffoldkit-planforge-workflow.md
+++ b/docs/scaffoldkit-planforge-workflow.md
@@ -23,7 +23,7 @@ Typical responsibilities:
 Current responsibilities:
 
 - read planning input and infer a first delivery phase and path
-- generate planning artifacts such as `project-charter.md`, `architecture-overview.md`, `delivery-plan.md`
+- generate planning artifacts such as `.planforge/docs/project-charter.md`, `.planforge/docs/architecture-overview.md`, `.planforge/docs/delivery-plan.md`
 - generate ADRs in `adrs/`
 - generate task documents in `tasks/`
 - generate prompt exports in `prompts/`
@@ -49,9 +49,9 @@ If you are updating older automation that expected root-level JSON artifacts, re
 
 - `planning/plan-output.json`
 - `planning/structured-input.json`
-- `project-charter.md`
-- `architecture-overview.md`
-- `delivery-plan.md`
+- `.planforge/docs/project-charter.md`
+- `.planforge/docs/architecture-overview.md`
+- `.planforge/docs/delivery-plan.md`
 - `adrs/*.md`
 - `tasks/*.md`
 - `prompts/*.md`
@@ -150,10 +150,9 @@ Start with:
 - `planforge-index.json`
 - `planning/structured-input.json`
 - `planning/plan-output.json`
-- `project-charter.md`
-- `architecture-overview.md`
-- `delivery-plan.md`
-- `AGENTS.md`
+- `.planforge/docs/project-charter.md`
+- `.planforge/docs/architecture-overview.md`
+- `.planforge/docs/delivery-plan.md`
 - `.ai/AGENTS.md`
 - `handoff/manifest.json`
 

--- a/scripts/analyze-artifacts.js
+++ b/scripts/analyze-artifacts.js
@@ -81,6 +81,14 @@ function resolvePlanOutputPath(projectDir) {
   return candidates.find((candidate) => fs.existsSync(candidate)) || candidates[0];
 }
 
+function resolveDocPath(projectDir, name) {
+  const candidates = [
+    path.join(projectDir, ".planforge", "docs", name),
+    path.join(projectDir, name)
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) || candidates[0];
+}
+
 function toMarkdownList(items) {
   if (!items.length) {
     return "- None";
@@ -218,8 +226,8 @@ function analyzeArtifacts(projectDir, repoRoot) {
   const planOutput = readJson(planOutputPath);
   const patterns = readJson(path.join(repoRoot, "config", "stack-patterns.json")).patterns || {};
   const taskDocs = loadTaskDocuments(path.join(projectDir, "tasks"));
-  const deliveryPlan = parseDeliveryPlan(path.join(projectDir, "delivery-plan.md"));
-  const charterFeatures = parseProjectCharter(path.join(projectDir, "project-charter.md"));
+  const deliveryPlan = parseDeliveryPlan(resolveDocPath(projectDir, "delivery-plan.md"));
+  const charterFeatures = parseProjectCharter(resolveDocPath(projectDir, "project-charter.md"));
 
   const issues = [];
   const passed = [];

--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -149,6 +149,10 @@ function exportsPath(...segments) {
   return path.join("exports", ...segments);
 }
 
+function docsPath(...segments) {
+  return path.join(".planforge", "docs", ...segments);
+}
+
 function writeStderrLine(message) {
   fs.writeSync(2, `${message}\n`);
 }
@@ -1892,8 +1896,8 @@ function buildTasks(input, phase, architecture, stackPatterns) {
       solution: "Create the charter, architecture overview, and first ADRs so later execution work inherits explicit assumptions instead of guesswork.",
       files: [
         "PROJECT.md",
-        "project-charter.md",
-        "architecture-overview.md",
+        docsPath("project-charter.md"),
+        docsPath("architecture-overview.md"),
         "adrs/001-initial-architecture-shape.md",
         "adrs/002-primary-data-store.md"
       ],
@@ -2644,7 +2648,7 @@ function renderIntakeFollowupPrompt(repoRoot, input, output) {
   return renderTemplate(repoRoot, "templates/intake-followup-prompt-template.md", {
     projectName: input.projectName,
     intakeCompleteness: output.intakeCompleteness,
-    startingPoint: "- Read `planforge-index.json` first for the generated artifact map.\n- Then review `AGENTS.md`, `intake-questionnaire.md`, and the current planning docs.",
+    startingPoint: "- Read `planforge-index.json` first for the generated artifact map.\n- Then review `AGENTS.md`, `.planforge/docs/intake-questionnaire.md`, and the current planning docs.",
     questions,
     applicablePlaybooks: toMarkdownList(output.recommendedPlaybooks)
   });
@@ -2795,8 +2799,8 @@ function buildHandoffManifest(input, output) {
             "planforge-index.json",
             planningPath("plan-output.json"),
             "PROJECT.md",
-            "intake-questionnaire.md",
-            "project-charter.md",
+            docsPath("intake-questionnaire.md"),
+            docsPath("project-charter.md"),
             ".ai/TASKS.md",
             intakePrompt.path
           ],
@@ -2834,9 +2838,9 @@ function buildHandoffManifest(input, output) {
             "planforge-index.json",
             planningPath("plan-output.json"),
             "PROJECT.md",
-            "architecture-overview.md",
+            docsPath("architecture-overview.md"),
             ".ai/ARCHITECTURE.md",
-            "delivery-plan.md",
+            docsPath("delivery-plan.md"),
             architecturePrompt.path
           ],
           writes: [
@@ -2926,7 +2930,7 @@ function buildHandoffManifest(input, output) {
             "planforge-index.json",
             planningPath("plan-output.json"),
             "PROJECT.md",
-            "delivery-plan.md",
+            docsPath("delivery-plan.md"),
             ".ai/TASKS.md",
             executionPrompt.path
           ].concat(waveTaskPaths),
@@ -2952,9 +2956,9 @@ function buildHandoffManifest(input, output) {
     planningPath("plan-output.json"),
     planningPath("structured-input.json"),
     "PROJECT.md",
-    "project-charter.md",
-    "architecture-overview.md",
-    "delivery-plan.md",
+    docsPath("project-charter.md"),
+    docsPath("architecture-overview.md"),
+    docsPath("delivery-plan.md"),
     handoffPath("runner-contract.json"),
     exportsPath("devreview.json"),
     exportsPath("scaffoldkit-input.json"),
@@ -2965,7 +2969,7 @@ function buildHandoffManifest(input, output) {
   ].concat(output.recommendedPlaybooks);
 
   if (output.intakeCompleteness !== "complete") {
-    manifestArtifacts.push("intake-questionnaire.md");
+    manifestArtifacts.push(docsPath("intake-questionnaire.md"));
   }
 
     output.adrCandidates.forEach((adr, index) => {
@@ -3086,9 +3090,9 @@ function buildRerunReport(mode, previousRun, input, output) {
     planningPath("plan-output.json"),
     handoffPath("manifest.json"),
     "PROJECT.md",
-    "project-charter.md",
-    "architecture-overview.md",
-    "delivery-plan.md",
+    docsPath("project-charter.md"),
+    docsPath("architecture-overview.md"),
+    docsPath("delivery-plan.md"),
     handoffPath("runner-contract.json"),
     exportsPath("scaffoldkit-input.json"),
     exportsPath("devreview.json")
@@ -3292,13 +3296,14 @@ function renderPlanforgeIndex(output) {
       agents: "AGENTS.md",
       claude: "CLAUDE.md",
       project: "PROJECT.md",
-      charter: "project-charter.md",
-      architecture: "architecture-overview.md",
-      deliveryPlan: "delivery-plan.md",
-      intakeQuestionnaire: "intake-questionnaire.md"
+      charter: docsPath("project-charter.md"),
+      architecture: docsPath("architecture-overview.md"),
+      deliveryPlan: docsPath("delivery-plan.md"),
+      intakeQuestionnaire: docsPath("intake-questionnaire.md")
     },
     directories: {
       ai: ".ai",
+      docs: docsPath(),
       planning: "planning",
       handoff: "handoff",
       exports: "exports",
@@ -3952,10 +3957,10 @@ function main() {
     writeFile(path.join(outdir, planningPath("plan-output.json")), `${JSON.stringify(output, null, 2)}\n`);
     writeFile(path.join(outdir, handoffPath("manifest.json")), `${JSON.stringify(output.handoffManifest, null, 2)}\n`);
     writeFile(path.join(outdir, "PROJECT.md"), renderProjectIndex(planforgeRoot, input, output));
-    writeFile(path.join(outdir, "intake-questionnaire.md"), renderIntakeQuestionnaire(planforgeRoot, input, output));
-    writeFile(path.join(outdir, "project-charter.md"), renderProjectCharter(input, output));
-    writeFile(path.join(outdir, "architecture-overview.md"), renderArchitectureOverview(input, output));
-    writeFile(path.join(outdir, "delivery-plan.md"), renderDeliveryPlan(output));
+    writeFile(path.join(outdir, docsPath("intake-questionnaire.md")), renderIntakeQuestionnaire(planforgeRoot, input, output));
+    writeFile(path.join(outdir, docsPath("project-charter.md")), renderProjectCharter(input, output));
+    writeFile(path.join(outdir, docsPath("architecture-overview.md")), renderArchitectureOverview(input, output));
+    writeFile(path.join(outdir, docsPath("delivery-plan.md")), renderDeliveryPlan(output));
     writeAiArtifacts(input, output, outdir, scaffoldkitContext, planforgeIndex);
     writeOperationalArtifacts(input, output, outdir, rerunReport, scaffoldkitContext);
     writeTemplateArtifacts(planforgeRoot, input, output, outdir, config);

--- a/templates/project-template.md
+++ b/templates/project-template.md
@@ -17,9 +17,9 @@ Use it to understand the current plan quickly and jump to the source artifacts t
 
 ## Source Artifacts
 
-- [Project Charter](project-charter.md): scope, users, constraints, open questions
-- [Architecture Overview](architecture-overview.md): starting architecture, tradeoffs, risks
-- [Delivery Plan](delivery-plan.md): execution waves and dependency ordering
+- [Project Charter](.planforge/docs/project-charter.md): scope, users, constraints, open questions
+- [Architecture Overview](.planforge/docs/architecture-overview.md): starting architecture, tradeoffs, risks
+- [Delivery Plan](.planforge/docs/delivery-plan.md): execution waves and dependency ordering
 - [Task Backlog](tasks/): executable work packages with acceptance criteria
 - [ADRs](adrs/): early high-leverage decisions
 - [Prompts](prompts/): downstream agent handoff prompts
@@ -27,9 +27,9 @@ Use it to understand the current plan quickly and jump to the source artifacts t
 
 ## Recommended Working Order
 
-1. Read `project-charter.md` for scope and unresolved questions.
-2. Read `architecture-overview.md` to confirm the recommended starting shape still fits.
-3. Read `delivery-plan.md` to understand wave sequencing and dependencies.
+1. Read `.planforge/docs/project-charter.md` for scope and unresolved questions.
+2. Read `.planforge/docs/architecture-overview.md` to confirm the recommended starting shape still fits.
+3. Read `.planforge/docs/delivery-plan.md` to understand wave sequencing and dependencies.
 4. Execute or refine the current wave tasks under `tasks/`.
 5. Update ADRs and prompts when architectural or governance assumptions move.
 

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -126,7 +126,7 @@ runCase("sample input generates enterprise artifacts, runner contract, and downs
   assert.ok(manifest.sharedArtifacts.includes("exports/scaffoldkit-input.json"));
   assert.ok(manifest.sharedArtifacts.includes("exports/devreview.json"));
   assert.match(projectIndex, /# PROJECT: Vendor Access Hub/);
-  assert.match(projectIndex, /\[Project Charter\]\(project-charter\.md\)/);
+  assert.match(projectIndex, /\[Project Charter\]\(\.planforge\/docs\/project-charter\.md\)/);
   assert.match(projectIndex, /## Current Wave/);
   assert.match(projectIndex, /## Architecture Guardrails/);
   assert.match(rootAgentsDoc, /Primary agent instructions live in `\.ai\/AGENTS\.md`/);
@@ -151,6 +151,11 @@ runCase("sample input generates enterprise artifacts, runner contract, and downs
   assert.equal(planforgeIndex.handoff.manifest, "handoff/manifest.json");
   assert.equal(planforgeIndex.exports.scaffoldkit, "exports/scaffoldkit-input.json");
   assert.equal(planforgeIndex.rootFiles.agents, "AGENTS.md");
+  assert.equal(planforgeIndex.rootFiles.charter, ".planforge/docs/project-charter.md");
+  assert.equal(planforgeIndex.rootFiles.architecture, ".planforge/docs/architecture-overview.md");
+  assert.equal(planforgeIndex.rootFiles.deliveryPlan, ".planforge/docs/delivery-plan.md");
+  assert.equal(planforgeIndex.rootFiles.intakeQuestionnaire, ".planforge/docs/intake-questionnaire.md");
+  assert.equal(planforgeIndex.directories.docs, ".planforge/docs");
   assert.equal(planforgeIndex.directories.ai, ".ai");
   assert.equal(planforgeIndex.ai.tasks, ".ai/TASKS.md");
 
@@ -163,6 +168,10 @@ runCase("sample input generates enterprise artifacts, runner contract, and downs
     ".ai/TASKS.md",
     ".ai/DECISIONS.md",
     "PROJECT.md",
+    ".planforge/docs/project-charter.md",
+    ".planforge/docs/architecture-overview.md",
+    ".planforge/docs/delivery-plan.md",
+    ".planforge/docs/intake-questionnaire.md",
     "governance/service-ownership.md",
     "prompts/governance-setup.md",
     "handoff/runner/step-4-wave-1-execution/status.json",
@@ -320,7 +329,7 @@ runCase("django plans emit a weak scaffold match and tell the agent to create or
 
   const outdir = path.join(fixtureDir, "out");
   const scaffoldkit = readJson(exportsFile(outdir, "scaffoldkit-input.json"));
-  const architectureOverview = readText(path.join(outdir, "architecture-overview.md"));
+  const architectureOverview = readText(path.join(outdir, ".planforge", "docs", "architecture-overview.md"));
   const agentsDoc = readText(path.join(outdir, ".ai", "AGENTS.md"));
 
   assert.equal(scaffoldkit.blueprint, "rest-api");


### PR DESCRIPTION
## Summary

Phase 1 of a phased output-layout redesign for agent-planforge. The generated planning pack currently writes ~20 files straight into the target project root. This change relocates the four planning prose docs into `.planforge/docs/`, keeping the root focused on the agent-discovery and discovery-anchor files.

Moved into `.planforge/docs/`: `project-charter.md`, `architecture-overview.md`, `delivery-plan.md`, `intake-questionnaire.md`.
Kept at root: `AGENTS.md`, `CLAUDE.md`, `PROJECT.md`, `planforge-index.json`.

## How it stays consistent

- A new `docsPath()` helper (sibling to `planningPath`/`handoffPath`/`exportsPath`) is the single definition of the new location.
- `planforge-index.json` `rootFiles` values point at `.planforge/docs/...` and the index gains a `directories.docs` entry. The index schema and `version` are unchanged, so index-honoring consumers (project-forge follows `index.rootFiles.architecture`) self-correct.
- Every internal reference moves in lockstep: runner-contract `reads:` arrays, handoff manifest `sharedArtifacts`, rerun `regeneratedArtifacts`, task-001 `files`, the `PROJECT.md` template links, `config/planner-config.json` artifact expectations, and the layout docs.
- `analyze-artifacts` reads the docs via a candidate list (`.planforge/docs/<name>` then legacy root), so it parses both new and old outputs.

## Tests

- `npm run test:cli` (22) and `npm run test:server` (47) green.
- New assertions lock the `rootFiles` values, `directories.docs`, the `PROJECT.md` link, and doc existence at the new path.
- Reviewed by a subagent; one missed doc reference in `scaffoldkit-planforge-workflow.md` was fixed.

## Out of scope (Phase 2)

Write-registry-derived index, relocating `.ai/`/`planning/`/`handoff/`/`exports/` and the tooling files, schema v2 plus version bump, fail-loud resolver.

Note: `out/` is gitignored, so regenerated examples are not part of the diff.

Refs: design produced by a multi-agent workflow (4 readers, 3 layout proposals, judge panel, synthesis, 3 adversarial verifiers).