### PR TITLE
refactor(output-layout): relocate tooling templates + presence-accurate index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `analyze-artifacts` resolves the docs from the new location and still
   reads legacy root-level outputs. First step of a phased output-layout
   redesign; see `docs/output-layout-migration.md`.
+- Output layout: the generated tooling templates (`Makefile`,
+  `Dockerfile.dev`, `docker-compose.dev.yml`, `.dockerignore`,
+  `.husky-pre-commit`, `lint-staged.config.js`, `BRANCH_INFO.md`) now
+  generate under `.planforge/tooling/` instead of the project root. This
+  declutters the root and stops planforge's generic copies from overwriting
+  scaffoldkit's blueprint-specific root files. `planforge-index.json` gains a
+  `directories.tooling` entry; the individual tooling files stay out of the
+  index as before, and the index `version` is unchanged.
+- `planforge-index.json` `directories` is now presence-accurate: the
+  conditional `governance`, `runbooks`, and `specs` entries appear only when
+  those directories are actually generated (enterprise path,
+  production-oriented phases, and `--clarify` respectively), instead of being
+  listed unconditionally.
 
 ## [0.2.0] - 2026-04-24
 

--- a/docs/output-layout-migration.md
+++ b/docs/output-layout-migration.md
@@ -16,6 +16,7 @@ Planning prose and machine-oriented artifacts now live in grouped directories.
 ## New Layout
 
 - `.planforge/docs/` for planning prose (charter, architecture overview, delivery plan, intake questionnaire)
+- `.planforge/tooling/` for generic tooling templates (Makefile, Docker dev files, pre-commit helpers, BRANCH_INFO)
 - `planning/` for planning state and rerun metadata
 - `handoff/` for orchestration and runner state
 - `exports/` for downstream tool exports
@@ -38,6 +39,13 @@ Planning prose and machine-oriented artifacts now live in grouped directories.
 | `architecture-overview.md` | `.planforge/docs/architecture-overview.md` |
 | `delivery-plan.md` | `.planforge/docs/delivery-plan.md` |
 | `intake-questionnaire.md` | `.planforge/docs/intake-questionnaire.md` |
+| `Makefile` | `.planforge/tooling/Makefile` |
+| `Dockerfile.dev` | `.planforge/tooling/Dockerfile.dev` |
+| `docker-compose.dev.yml` | `.planforge/tooling/docker-compose.dev.yml` |
+| `.dockerignore` | `.planforge/tooling/.dockerignore` |
+| `.husky-pre-commit` | `.planforge/tooling/.husky-pre-commit` |
+| `lint-staged.config.js` | `.planforge/tooling/lint-staged.config.js` |
+| `BRANCH_INFO.md` | `.planforge/tooling/BRANCH_INFO.md` |
 
 ## Compatibility Notes
 

--- a/docs/scaffoldkit-planforge-workflow.md
+++ b/docs/scaffoldkit-planforge-workflow.md
@@ -70,13 +70,14 @@ If you are updating older automation that expected root-level JSON artifacts, re
 - `governance/` when the enterprise path applies
 - `runbooks/` when production-oriented phases apply
 
-### Shared By Convention
+### planforge Tooling Templates (under `.planforge/tooling/`)
 
-- `Makefile`
-- Docker dev files
-- pre-commit helper files
+- `.planforge/tooling/Makefile`
+- `.planforge/tooling/Dockerfile.dev`, `.planforge/tooling/docker-compose.dev.yml`, `.planforge/tooling/.dockerignore`
+- `.planforge/tooling/.husky-pre-commit`, `.planforge/tooling/lint-staged.config.js`
+- `.planforge/tooling/BRANCH_INFO.md`
 
-If scaffoldkit already created these files, planforge may overwrite them with its bundled templates. Review generated diffs instead of assuming merge behavior.
+planforge writes its generic tooling templates under `.planforge/tooling/`, so they no longer overwrite scaffoldkit's blueprint-specific root `Makefile`, Docker, or pre-commit files. scaffoldkit owns the root copies; treat planforge's as reference templates to wire in deliberately.
 
 ## End-To-End Workflow
 

--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -153,6 +153,10 @@ function docsPath(...segments) {
   return path.join(".planforge", "docs", ...segments);
 }
 
+function toolingPath(...segments) {
+  return path.join(".planforge", "tooling", ...segments);
+}
+
 function writeStderrLine(message) {
   fs.writeSync(2, `${message}\n`);
 }
@@ -3282,7 +3286,7 @@ Primary references:
 `;
 }
 
-function renderPlanforgeIndex(output) {
+function renderPlanforgeIndex(output, presence = {}) {
   return {
     version: "1.0",
     generatedBy: "agent-planforge",
@@ -3304,15 +3308,18 @@ function renderPlanforgeIndex(output) {
     directories: {
       ai: ".ai",
       docs: docsPath(),
+      tooling: toolingPath(),
       planning: "planning",
       handoff: "handoff",
       exports: "exports",
       prompts: "prompts",
-      specs: "specs",
       adrs: "adrs",
       tasks: "tasks",
-      governance: "governance",
-      runbooks: "runbooks"
+      // Conditional directories: emitted only when actually generated, so the
+      // index never advertises a directory that is absent on disk.
+      ...(presence.specs ? { specs: "specs" } : {}),
+      ...(presence.runbooks ? { runbooks: "runbooks" } : {}),
+      ...(presence.governance ? { governance: "governance" } : {})
     },
     planning: {
       planOutput: planningPath("plan-output.json"),
@@ -3708,7 +3715,7 @@ function writeTemplateArtifacts(repoRoot, input, output, outdir, config) {
 function writeMakefile(repoRoot, outdir) {
   const templatePath = path.join(repoRoot, "templates", "Makefile.template");
   const makefileContent = readText(templatePath, "Makefile.template");
-  writeFile(path.join(outdir, "Makefile"), makefileContent);
+  writeFile(path.join(outdir, toolingPath("Makefile")), makefileContent);
 }
 
 function readScaffoldkitBlueprint(outdir) {
@@ -3765,9 +3772,9 @@ function writeDockerFiles(repoRoot, outdir) {
   const dockerfileContent = readText(dockerfilePath, "Dockerfile.dev.template");
   const dockerignoreContent = readText(dockerignorePath, ".dockerignore.template");
   
-  writeFile(path.join(outdir, "docker-compose.dev.yml"), dockerComposeContent);
-  writeFile(path.join(outdir, "Dockerfile.dev"), dockerfileContent);
-  writeFile(path.join(outdir, ".dockerignore"), dockerignoreContent);
+  writeFile(path.join(outdir, toolingPath("docker-compose.dev.yml")), dockerComposeContent);
+  writeFile(path.join(outdir, toolingPath("Dockerfile.dev")), dockerfileContent);
+  writeFile(path.join(outdir, toolingPath(".dockerignore")), dockerignoreContent);
 }
 
 function writePreCommitHooks(repoRoot, outdir) {
@@ -3777,8 +3784,8 @@ function writePreCommitHooks(repoRoot, outdir) {
   const huskyPreCommitContent = readText(huskyPreCommitPath, ".husky-pre-commit.template");
   const lintStagedConfigContent = readText(lintStagedConfigPath, "lint-staged.config.js.template");
   
-  writeFile(path.join(outdir, ".husky-pre-commit"), huskyPreCommitContent);
-  writeFile(path.join(outdir, "lint-staged.config.js"), lintStagedConfigContent);
+  writeFile(path.join(outdir, toolingPath(".husky-pre-commit")), huskyPreCommitContent);
+  writeFile(path.join(outdir, toolingPath("lint-staged.config.js")), lintStagedConfigContent);
 }
 
 function writeBranchInfo(repoRoot, outdir, defaultBranch, autoDetected) {
@@ -3793,7 +3800,7 @@ function writeBranchInfo(repoRoot, outdir, defaultBranch, autoDetected) {
   content = content.replace(/{{defaultBranch}}/g, defaultBranch);
   content = content.replace(/{{detectionMethod}}/g, detectionMethod);
   
-  writeFile(path.join(outdir, "BRANCH_INFO.md"), content);
+  writeFile(path.join(outdir, toolingPath("BRANCH_INFO.md")), content);
 }
 
 function detectDefaultBranch(outdir) {
@@ -3923,7 +3930,11 @@ function main() {
     const rerunMode = args.resumeFrom ? "resume" : args.rerunFrom ? "rerun" : "fresh";
     const output = buildOutput(input, config, playbookContext, planforgeRoot, inputMetadata);
     const promptArtifacts = buildPromptArtifacts(planforgeRoot, input, output);
-    const planforgeIndex = renderPlanforgeIndex(output);
+    const planforgeIndex = renderPlanforgeIndex(output, {
+      governance: output.path === "enterprise",
+      runbooks: output.phase === "phase_2" || output.phase === "phase_3",
+      specs: args.clarify === true
+    });
 
     output.promptExports = promptArtifacts.map(({ contents, ...metadata }) => metadata);
     output.handoffManifest = buildHandoffManifest(input, output);

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -156,7 +156,13 @@ runCase("sample input generates enterprise artifacts, runner contract, and downs
   assert.equal(planforgeIndex.rootFiles.deliveryPlan, ".planforge/docs/delivery-plan.md");
   assert.equal(planforgeIndex.rootFiles.intakeQuestionnaire, ".planforge/docs/intake-questionnaire.md");
   assert.equal(planforgeIndex.directories.docs, ".planforge/docs");
+  assert.equal(planforgeIndex.directories.tooling, ".planforge/tooling");
   assert.equal(planforgeIndex.directories.ai, ".ai");
+  // Enterprise phase_3 run: governance + runbooks are written, so they appear;
+  // specs is not (no --clarify), so it must be absent from the index.
+  assert.equal(planforgeIndex.directories.governance, "governance");
+  assert.equal(planforgeIndex.directories.runbooks, "runbooks");
+  assert.equal(planforgeIndex.directories.specs, undefined);
   assert.equal(planforgeIndex.ai.tasks, ".ai/TASKS.md");
 
   [
@@ -181,7 +187,7 @@ runCase("sample input generates enterprise artifacts, runner contract, and downs
     assert.ok(fs.existsSync(path.join(outdir, relativePath)), `missing ${relativePath}`);
   });
 
-  assert.equal(fs.existsSync(path.join(outdir, "Makefile")), true);
+  assert.equal(fs.existsSync(path.join(outdir, ".planforge", "tooling", "Makefile")), true);
 });
 
 runCase("service-oriented plans export a real scaffoldkit backend blueprint", () => {
@@ -243,9 +249,15 @@ runCase("git-backed cli sync plans stay on cli-tool semantics and avoid database
   assert.ok(featureTasks.some((task) => task.files.some((file) => file.includes("memory-sync"))));
   assert.equal(featureTasks.some((task) => task.files.some((file) => /notifications|widgets|github/i.test(file))), false);
 
-  assert.equal(fs.existsSync(path.join(outdir, "Makefile")), false);
-  assert.equal(fs.existsSync(path.join(outdir, "Dockerfile.dev")), false);
-  assert.equal(fs.existsSync(path.join(outdir, "docker-compose.dev.yml")), false);
+  assert.equal(fs.existsSync(path.join(outdir, ".planforge", "tooling", "Makefile")), false);
+  assert.equal(fs.existsSync(path.join(outdir, ".planforge", "tooling", "Dockerfile.dev")), false);
+  assert.equal(fs.existsSync(path.join(outdir, ".planforge", "tooling", "docker-compose.dev.yml")), false);
+
+  // Core (cli-tool) plan: governance is enterprise-only, so it must be absent
+  // from the index; the tooling directory anchor is always present.
+  const cliIndex = readJson(path.join(outdir, "planforge-index.json"));
+  assert.equal(cliIndex.directories.governance, undefined);
+  assert.equal(cliIndex.directories.tooling, ".planforge/tooling");
 });
 
 runCase("php symfony backend plans recommend the symfony backend blueprint", () => {
@@ -497,7 +509,10 @@ runCase("auto-clarify accepts defaults and proceeds without waiting", () => {
 
   const clarifications = fs.readFileSync(path.join(fixtureDir, "out", "specs", "clarifications.md"), "utf8");
   const output = readJson(planningFile(path.join(fixtureDir, "out"), "plan-output.json"));
+  const planforgeIndex = readJson(path.join(fixtureDir, "out", "planforge-index.json"));
 
+  // --clarify generated specs/clarifications.md, so the index must list specs.
+  assert.equal(planforgeIndex.directories.specs, "specs");
   assert.match(clarifications, /Answer: approval-based email\/password authentication/);
   assert.ok(output.inputSnapshot.constraints.some((item) => item.startsWith("Authentication strategy:")));
   assert.ok(output.inputSnapshot.constraints.some((item) => item.startsWith("Deployment target:")));


### PR DESCRIPTION
## Summary

Lean Phase 2 slice of the output-layout redesign (chosen over the full relocation). Two independent, non-breaking wins in agent-planforge; the index `version` stays `1.0` and project-forge needs no change.

## 1. Tooling templates move to `.planforge/tooling/`

A `toolingPath()` helper (sibling to `docsPath()`); `writeMakefile`/`writeDockerFiles`/`writePreCommitHooks`/`writeBranchInfo` now write `Makefile`, `Dockerfile.dev`, `docker-compose.dev.yml`, `.dockerignore`, `.husky-pre-commit`, `lint-staged.config.js`, `BRANCH_INFO.md` under `.planforge/tooling/`. This declutters the generated root and ends a latent scaffoldkit `--overwrite` collision: planforge's generic copies no longer clobber scaffoldkit's blueprint-specific root files. The index gains `directories.tooling` (always present, since `BRANCH_INFO.md` is written unconditionally); the individual tooling files stay out of the index as before.

## 2. Presence-accurate index

`renderPlanforgeIndex(output, presence)` now emits the conditional `directories` entries `governance`/`runbooks`/`specs` only when actually generated (enterprise path, phase_2/phase_3, and `--clarify`), computed from `output`/`args` at the single call site with no filesystem access, so `--validate-only` still validates. Previously a minimal run advertised directories that did not exist. `directories` keeps `minProperties>=1` (nine unconditional keys remain), so project-forge's `isPlanforgeIndex` still validates and it reads `directories.tasks` as before.

## Tests

`npm run test:cli` (22) + `npm run test:server` (47) green. New assertions lock: enterprise run has governance/runbooks present + specs absent + tooling present; core run has governance absent + tooling present; auto-clarify run has specs present; tooling files resolve under `.planforge/tooling/`. Reviewed by a subagent (one test-gap nit fixed: the positive specs branch is now pinned).

## Deliberately deferred to Phase 2b

Individual tooling files in the index (needs the derive-after-write re-architecture, since the index is built before writes and validated in `--validate-only`), the full single-write-registry, relocating `.ai/`/`planning/`/`handoff/`/`exports/`/`adrs/`/`tasks/`, schema v2 + version bump, and the scaffoldkit `.ai/` overlap decision. Tracked in task `9da901b9`.

Refs: design from a multi-agent workflow incl. adversarial verifiers.