### PR TITLE
fix(scaffoldkit): pass --no-ai-context so generated .ai/ survives scaffolding

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -45,10 +45,11 @@ RUN cd server && npm run build
 # and the venv's python3 binary would fail at runtime with
 # `cannot open shared object file: libpython3.12.so.1.0`.
 FROM python:3.11-slim AS scaffoldkit
-# Pinned to https://github.com/LanNguyenSi/scaffoldkit @ 333e0f7 (2026-04).
+# Pinned to https://github.com/LanNguyenSi/scaffoldkit @ 59ccd5b (2026-05).
 # Update this when bumping scaffoldkit; image build will pull a fresh
-# clone and rebuild the venv.
-ARG SCAFFOLDKIT_REF=333e0f7
+# clone and rebuild the venv. 59ccd5b adds the --no-ai-context flag that
+# generate.ts passes, so scaffoldkit no longer clobbers planforge's .ai/.
+ARG SCAFFOLDKIT_REF=59ccd5b
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y git ca-certificates \

--- a/server/src/generate.ts
+++ b/server/src/generate.ts
@@ -203,11 +203,14 @@ async function runScaffoldkit(args: {
   abortSignal?: AbortSignal;
 }): Promise<{ exitCode: number; stderr: string }> {
   return await new Promise((resolvePromise, rejectPromise) => {
-    // Arg shape mirrors what project-forge has been running in the old
-    // subprocess path: `from-planforge <input> --target <outdir>
-    // --overwrite --no-install`. `--no-install` keeps the service off
-    // the network and prevents scaffoldkit from running `npm install`
-    // inside the HTTP service's tempdir.
+    // Arg shape: `from-planforge <input> --target <outdir> --overwrite
+    // --no-install --no-ai-context`. `--no-install` keeps the service off the
+    // network and prevents scaffoldkit from running `npm install` inside the
+    // HTTP service's tempdir. `--no-ai-context` stops scaffoldkit re-emitting
+    // its blueprint .ai/ tree (and AI_CONTEXT.md): the planforge CLI already
+    // wrote the canonical, plan-derived .ai/ into outdir above, and --overwrite
+    // would otherwise silently clobber it. The flag requires the scaffoldkit
+    // pinned by SCAFFOLDKIT_REF in server/Dockerfile (>= 59ccd5b).
     const child = spawn(
       args.python,
       [
@@ -219,6 +222,7 @@ async function runScaffoldkit(args: {
         args.outdir,
         "--overwrite",
         "--no-install",
+        "--no-ai-context",
       ],
       {
         cwd: args.outdir,


### PR DESCRIPTION
## What
Pass `--no-ai-context` to scaffoldkit's `from-planforge` and bump `SCAFFOLDKIT_REF` to the scaffoldkit commit that adds the flag.

## Why
The planforge CLI writes a rich, plan-derived root `.ai/{AGENTS,ARCHITECTURE,TASKS,DECISIONS}.md` into `outdir`, then `runScaffoldkit` spawns `scaffoldkit.cli from-planforge <input> --target <same outdir> --overwrite`. For the two blueprints that ship a root `.ai/` tree (express-api, nextjs-fullstack), scaffoldkit's static placeholders silently clobbered planforge's files (data loss; verified 2 of 13 blueprints).

## Change
- `server/src/generate.ts`: append `--no-ai-context` to the from-planforge spawn args. planforge owns the `.ai/` context, so scaffoldkit should not re-emit (and overwrite) it.
- `server/Dockerfile`: bump `SCAFFOLDKIT_REF` `333e0f7` to `59ccd5b` (scaffoldkit PR #45, which adds the flag). The pin guarantees the container's scaffoldkit understands the flag, so no version skew.

## Verification
- Server suite green (47); the routes.test.ts stub-scaffoldkit walks argv for `--target` and tolerates the extra flag.
- `tsc` build clean.
- The CI Docker smoke step builds the image at the bumped ref and drives a live `POST /api/generate` asserting scaffoldkit `invoked && exitCode == 0`, so flag/pin consistency is enforced end-to-end.
- The fix itself (a pre-existing `.ai/` surviving `--overwrite --no-ai-context`) is covered by scaffoldkit's regression test and dogfood in PR #45.

## Deploy
Takes effect on the next planforge container rebuild (the image clones+checks out the ref at build time). A redeploy of the current image will not pick it up.

Refs: task 8e10ec47; pairs with scaffoldkit PR #45