### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-01
+
 ### Added
 
+- HTTP server boot-guard: the service refuses to start unless
+  `SCAFFOLDKIT_PYTHON` resolves to a runnable interpreter, failing fast
+  at startup instead of surfacing a broken scaffolding path mid-request.
+  `/healthz` gains a `status` field so callers can distinguish a healthy
+  boot from a degraded one.
 - HTTP server: `scaffoldkit.skipped` on the `done` event gains a fifth
   value `"input_unreadable"` plus an optional `inputReadError?: string`
   field. Previously every failure reading `exports/scaffoldkit-input.json`
@@ -16,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   hiding a broken CLI behind a normal-path no-op. ENOENT still maps to
   `"no_input"`; any other read or `JSON.parse` failure now reports
   `"input_unreadable"` with the underlying error message in
-  `inputReadError`. The field is optional and additive — existing
+  `inputReadError`. The field is optional and additive: existing
   consumers ignoring it are unaffected.
 
 ### Changed
@@ -45,6 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   those directories are actually generated (enterprise path,
   production-oriented phases, and `--clarify` respectively), instead of being
   listed unconditionally.
+- Scaffolding now passes `--no-ai-context` to scaffoldkit so a generated
+  `.ai/` directory survives scaffolding instead of being overwritten by
+  scaffoldkit's own context output.
+
+### Security
+
+- Bumped `fast-uri` and `hono` to patched releases (CVE sweep,
+  2026-05-10).
 
 ## [0.2.0] - 2026-04-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-planforge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-planforge",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-planforge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Planning bootstrap for agentic architecture and task generation",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Release v0.3.0

Rolls up all merged work since v0.2.0. No source changes in this PR: it promotes the `[Unreleased]` changelog to `[0.3.0]` and bumps the version.

### Highlights

- **Added:** `SCAFFOLDKIT_PYTHON` boot-guard plus a `/healthz` status field (#67); the `input_unreadable` skip value with `inputReadError` so a broken CLI is no longer hidden behind a normal-path no-op (#71).
- **Changed:** output-layout relocation of planning docs and tooling templates under `.planforge/`, with a presence-accurate index (#73, #74); `--no-ai-context` passthrough so a generated `.ai/` directory survives scaffolding (#76).
- **Security:** `fast-uri` and `hono` bumped to patched releases (CVE sweep, #69).

Version bumped to 0.3.0 in `package.json` and `package-lock.json`. Merging this and pushing tag `v0.3.0` triggers the tag-driven release workflow, which extracts the `## [0.3.0]` changelog section as the GitHub Release body.

Refs: agent-tasks f22c491b