### PR TITLE
fix(output): scrub dangling artifact references from generated AGENTS.md and PROJECT.md

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -2825,9 +2825,6 @@ For machine-readable path discovery, read \`planforge-index.json\`.
 
 ## Generated Directories
 
-- Planning state: \`planning/\`
-- Tool exports: \`exports/\`
-- Clarifications: \`specs/\`
 - ADRs: \`adrs/\`
 - Tasks: \`tasks/\`
 
@@ -2840,12 +2837,8 @@ For machine-readable path discovery, read \`planforge-index.json\`.
 ## Important Files
 
 - Machine-readable index: \`planforge-index.json\`
-- Planning output: \`${planningPath("plan-output.json")}\`
-- Structured input snapshot: \`${planningPath("structured-input.json")}\`
-- Rerun metadata: \`${planningPath("rerun-report.json")}\`
 - Architecture: \`${docsPath("architecture-overview.md")}\`
 - Delivery plan: \`${docsPath("delivery-plan.md")}\`
-- Scaffold export: \`${exportsPath("scaffoldkit-input.json")}\`
 
 ## Working Notes
 

--- a/templates/project-template.md
+++ b/templates/project-template.md
@@ -67,5 +67,5 @@ Use it to understand the current plan quickly and jump to the source artifacts t
 ## Notes
 
 - `PROJECT.md` is a generated index, not the detailed source of truth.
-- When detailed plan artifacts disagree, prefer `plan-output.json`, task documents, and ADRs over summary text here.
+- When detailed plan artifacts disagree, prefer the task documents and ADRs over summary text here.
 - If the plan changes materially, rerun the planner so this file stays aligned with the backlog.


### PR DESCRIPTION
## What

Scrub dangling artifact references from the generated, committed agent-facing docs (AGENTS.md, PROJECT.md) so a downstream coding agent in a published repo is never pointed at files that are not in the deliverable.

## Why

Found by the r2 re-dogfood (github.com/LanNguyenSi/dogfood-quicklinks-r2). After the runner/handoff kill (#78) and project-forge's publish exclusion (#79), AGENTS.md still listed exports/, specs/, plan-output.json, structured-input.json, rerun-report.json and scaffoldkit-input.json, and PROJECT.md still steered at plan-output.json. None of those survive into the published repo, so a fresh implementer dead-ends on them.

## Changes

- AGENTS.md "Generated Directories": keep adrs/ and tasks/; drop exports/, specs/, planning/.
- AGENTS.md "Important Files": keep planforge-index.json, architecture-overview.md, delivery-plan.md; drop the plan-output/structured-input/rerun-report/scaffoldkit-input entries.
- PROJECT.md: prefer task documents and ADRs over plan-output.json.

planforge-index.json is deliberately unchanged: project-forge derives its publish-exclude patterns from it, so its entries must stay. The separate concern that the published index still advertises excluded paths to machine consumers is a follow-up, not part of this fix.

## Test plan

- npm run test (test:cli + test:server) green; no test asserts the removed prose.
- Reviewed by a review subagent (verdict: ship, no must-fix).

Refs: agent-tasks 6ffd34f6