### PR TITLE
fix(blueprint): word-boundary the CLI selector and add a REST/HTTP-API branch

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -1682,7 +1682,7 @@ function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
     candidates = ["static-site", "nextjs-frontend", "nextjs-fullstack"];
     reason = "The request reads like a content-oriented or marketing-style site rather than an application backend.";
     confidence = "strong";
-  } else if (/(cli|command line|terminal tool|developer tool|code generator|scaffold)/.test(combinedText)) {
+  } else if (/\b(cli|command line|terminal tool|developer tool|code generator|scaffold)\b/.test(combinedText)) {
     candidates = ["cli-tool", "express-api", "rest-api"];
     reason = "The request reads like an internal or developer-facing tool with command-style workflows.";
     confidence = "strong";
@@ -1699,6 +1699,13 @@ function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
     reason = "The request points to a Django-style backend, but only the generic REST API scaffold is currently available.";
     confidence = "weak";
     manualStructureReason = "Use the generated scaffold only as a starting point. The agent should expect to create or adapt the Django-specific project structure manually.";
+  } else if (
+    /\b(rest api|rest\/json|json api|json over http|http api|web api|api service|api endpoints?)\b/.test(combinedText) &&
+    !/\b(cli|command line|terminal)\b/.test(combinedText)
+  ) {
+    candidates = ["rest-api", "express-api"];
+    reason = "The request reads like a REST/JSON HTTP API service, so an API-first scaffold is the closest fit.";
+    confidence = "strong";
   } else if (/python application/.test(techStack)) {
     candidates = ["rest-api", "cli-tool"];
     reason = "The request points to a Python application, but there is no Python app scaffold that cleanly matches the requested shape.";

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -198,6 +198,33 @@ runCase("service-oriented plans export a real scaffoldkit backend blueprint", ()
   assert.equal(scaffoldkit.suggestedVariables.use_queue, true);
 });
 
+runCase("rest/json api intakes select rest-api at strong confidence (the 'cli' substring in Clients/click must not trip cli-tool)", () => {
+  const fixtureDir = tempDir("planforge-rest-api-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "quicklinks-api",
+    summary: "A REST/JSON HTTP API service for shortening URLs. Clients POST a long URL and get back a short code.",
+    targetUsers: ["backend developers", "api consumers"],
+    coreFeatures: [
+      "POST /api/shorten accepting {url} and returning {code, shortUrl} as JSON",
+      "GET /:code issuing a 302 redirect to the original URL",
+      "per-link click analytics exposed via GET /api/links/:code/stats"
+    ],
+    constraints: [
+      "REST/JSON over HTTP only, no server-rendered UI",
+      "stateless service",
+      "PostgreSQL as the system of record"
+    ]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  const scaffoldkit = readJson(exportsFile(path.join(fixtureDir, "out"), "scaffoldkit-input.json"));
+  assert.equal(scaffoldkit.blueprint, "rest-api");
+  assert.equal(scaffoldkit.blueprintConfidence, "strong");
+  assert.equal(scaffoldkit.agentMustCreateStructure, false);
+});
+
 runCase("git-backed cli sync plans stay on cli-tool semantics and avoid database defaults", () => {
   const fixtureDir = tempDir("planforge-cli-sync-");
   writeJson(path.join(fixtureDir, "input.json"), {


### PR DESCRIPTION
## What

Fix blueprint selection so a REST/JSON API intake is no longer mis-selected as the cli-tool blueprint.

## Why

Found by the r4 dogfood plus a root-cause map. The CLI-detection regex had no word boundaries, so "cli" matched inside "Clients" (the URL-shortener intake says "Clients POST a long URL...") and "click", selecting cli-tool with strong confidence for a pure REST API. That is the head of the stack-contradiction cascade (Python/typer scaffold, empty src/, mismatch gate).

## Changes

- scripts/bootstrap-plan.js: word-boundary the CLI branch regex; add a dedicated REST/HTTP-API branch (rest-api/express-api, strong) after the django branch (so the Django rest-api-weak case is not stolen) and before python/fallback, guarded against CLI intakes.
- tests/bootstrap-plan.test.js: a REST/JSON URL-shortener intake selects rest-api at strong confidence (proves both the word-boundary fix and the new branch); the genuine-CLI and Django-weak fixtures stay green.

## Test plan

- npm run test (test:cli + test:server) green.
- Reviewed by a subagent workflow (ship); confirmed by a dogfood.

Refs: agent-tasks bba9a78c