### PR TITLE
fix(tasks): generate blueprint-aware feature task file paths

### DIFF
--- a/config/stack-patterns.json
+++ b/config/stack-patterns.json
@@ -2,6 +2,7 @@
   "patterns": {
     "authentication-jwt": {
       "keywords": ["authentication", "jwt", "auth", "login", "register"],
+      "negativeKeywords": ["api key", "apikey", "api token"],
       "files": {
         "nextjs-fullstack": [
           "lib/auth/jwt.ts — Token generation + verification (jsonwebtoken)",

--- a/models/planning-output.schema.json
+++ b/models/planning-output.schema.json
@@ -157,6 +157,9 @@
         "enterprise"
       ]
     },
+    "scaffoldBlueprint": {
+      "type": "string"
+    },
     "recommendedPlaybooks": {
       "type": "array",
       "items": {

--- a/scripts/analyze-artifacts.js
+++ b/scripts/analyze-artifacts.js
@@ -203,9 +203,9 @@ function waveIndex(waveId) {
   return match ? Number(match[1]) : Number.POSITIVE_INFINITY;
 }
 
-function bestAlignedPattern(files, patterns, architectureShape) {
+function bestAlignedPattern(files, patterns, blueprint) {
   const candidates = Object.entries(patterns || {}).map(([patternName, pattern]) => {
-    const expectedFiles = resolvePatternFiles(pattern, architectureShape);
+    const expectedFiles = resolvePatternFiles(pattern, blueprint);
     return {
       patternName,
       expectedFiles,
@@ -364,9 +364,9 @@ function analyzeArtifacts(projectDir, repoRoot) {
       }
     }
 
-    const expectedFiles = resolvePatternFiles(semanticPattern.pattern, planOutput.architectureRecommendation.shape);
+    const expectedFiles = resolvePatternFiles(semanticPattern.pattern, planOutput.scaffoldBlueprint);
     const semanticScore = alignmentScore(actualFiles, expectedFiles);
-    const alignedPattern = bestAlignedPattern(actualFiles, patterns, planOutput.architectureRecommendation.shape);
+    const alignedPattern = bestAlignedPattern(actualFiles, patterns, planOutput.scaffoldBlueprint);
 
     if (
       alignedPattern &&

--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -1758,6 +1758,32 @@ function scaffoldkitExecutionGuidance(input, output, scaffoldkitContext) {
   };
 }
 
+// Map the selected scaffold blueprint to the language its generated task file
+// paths should use. This mirrors the framework/language choices in
+// scaffoldkitSuggestedVariables so the task layer stays coherent with the
+// scaffold's actual stack.
+function blueprintLanguage(blueprint, input) {
+  const techStack = inferTechStack(input).toLowerCase();
+  const constraintsText = (input.constraints || []).join(" ").toLowerCase();
+  switch (blueprint) {
+    case "rest-api":
+      // framework = express (TS) for a TypeScript service stack, else fastapi (Python).
+      return /typescript service stack/.test(techStack) ? "typescript" : "python";
+    case "cli-tool":
+      // language = typescript when the constraints ask for it, otherwise python (typer).
+      return /typescript/.test(constraintsText) ? "typescript" : "python";
+    case "reference-php-app":
+    case "symfony-backend":
+    case "symfony-nextjs":
+      // symfony-nextjs is a PHP backend with a Next.js frontend; feature task
+      // files default to the dominant PHP backend layout.
+      return "php";
+    default:
+      // nextjs-fullstack, nextjs-frontend, express-api, saas-dashboard, static-site, ...
+      return "typescript";
+  }
+}
+
 function scaffoldkitSuggestedVariables(input, output, blueprint) {
   const featuresText = (input.coreFeatures || []).join(" ").toLowerCase();
   const constraintsText = (input.constraints || []).join(" ").toLowerCase();
@@ -1863,45 +1889,110 @@ function gitMemorySyncFeatureFiles(feature) {
   return Array.from(new Set(files));
 }
 
-function featureFiles(feature, architectureShape, stackPatterns) {
-  if (isGitMemorySyncFeature(feature)) {
+function pascalCaseFromSlug(slug) {
+  return (
+    String(slug || "")
+      .split(/[-_]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join("") || "Feature"
+  );
+}
+
+// Generic per-feature file suggestions used when no stack pattern matches. The
+// layout is chosen for the selected blueprint's language so task paths stay
+// coherent with the scaffold (e.g. a FastAPI rest-api gets Python paths instead
+// of hardcoded TypeScript).
+function genericFeatureFiles(feature, architectureShape, stack) {
+  const slug = slugify(feature, 40) || "feature"; // Limit module names to 40 chars
+  const lower = feature.toLowerCase();
+  const language = (stack && stack.language) || "typescript";
+  const blueprint = (stack && stack.blueprint) || "";
+  const isBackgroundWork =
+    /approval|workflow|notification|queue/.test(lower) || /background jobs/.test(architectureShape);
+  const isAudit = /audit|review|approval/.test(lower);
+
+  if (language === "python") {
+    // Python module names are identifiers, so use snake_case (the kebab slug
+    // would produce non-importable module names like `foo-bar_service.py`).
+    const moduleName = slug.replace(/-/g, "_");
+    const files =
+      blueprint === "cli-tool"
+        ? [`src/commands/${moduleName}.py`, `src/core/${moduleName}.py`, `tests/test_${moduleName}.py`]
+        : [
+            `src/routes/${moduleName}.py`,
+            `src/services/${moduleName}_service.py`,
+            `src/repositories/${moduleName}_repository.py`,
+            `tests/integration/test_${moduleName}.py`
+          ];
+    if (isBackgroundWork) {
+      files.push(`src/jobs/${moduleName}_job.py`);
+    }
+    if (isAudit) {
+      files.push("src/services/audit_log.py");
+    }
+    return Array.from(new Set(files));
+  }
+
+  if (language === "php") {
+    const name = pascalCaseFromSlug(slug);
+    const files = [
+      `src/Controller/${name}Controller.php`,
+      `src/Service/${name}Service.php`,
+      `src/Repository/${name}Repository.php`,
+      `tests/${name}Test.php`
+    ];
+    if (isBackgroundWork) {
+      files.push(`src/MessageHandler/${name}Handler.php`);
+    }
+    if (isAudit) {
+      files.push("src/Service/AuditLogService.php");
+    }
+    return Array.from(new Set(files));
+  }
+
+  // TypeScript (default): modular layout.
+  const files = [
+    `src/modules/${slug}/index.ts`,
+    `src/modules/${slug}/${slug}.service.ts`,
+    `src/modules/${slug}/${slug}.repository.ts`,
+    `tests/integration/${slug}.test.ts`
+  ];
+  if (/dashboard|admin|form|portal/.test(lower)) {
+    files.unshift(`src/routes/${slug}.ts`);
+  }
+  if (isBackgroundWork) {
+    files.push(`src/jobs/${slug}.job.ts`);
+  }
+  if (isAudit) {
+    files.push("src/modules/audit/audit-log.ts");
+  }
+  return Array.from(new Set(files));
+}
+
+function featureFiles(feature, architectureShape, stackPatterns, stack) {
+  // The git-memory-sync layout is TypeScript-specific, so only short-circuit for
+  // a TypeScript (or unspecified) stack; other languages fall through to the
+  // language-aware layout below.
+  const language = (stack && stack.language) || "typescript";
+  if (language === "typescript" && isGitMemorySyncFeature(feature)) {
     return gitMemorySyncFeatureFiles(feature);
   }
 
-  // Try to match a known pattern
+  // Prefer a known stack pattern's files for the selected blueprint.
   if (stackPatterns && stackPatterns.patterns) {
     const match = matchPattern(feature, stackPatterns.patterns);
-    
+
     if (match && match.pattern.files) {
-      const patternFiles = resolvePatternFiles(match.pattern, architectureShape);
+      const patternFiles = resolvePatternFiles(match.pattern, stack && stack.blueprint);
       if (patternFiles.length) {
         return patternFiles;
       }
     }
   }
-  
-  // Fallback to generic pattern
-  const slug = slugify(feature, 40);  // Limit module names to 40 chars
-  const files = [
-    `src/modules/${slug}/index.ts`,
-    `src/modules/${slug}/${slug}.service.ts`,
-    `src/modules/${slug}/${slug}.repository.ts`,
-    `tests/integration/${slug}.test.js`
-  ];
 
-  if (/dashboard|admin|form|portal/.test(feature.toLowerCase())) {
-    files.unshift(`src/routes/${slug}.ts`);
-  }
-
-  if (/approval|workflow|notification|queue/.test(feature.toLowerCase()) || /background jobs/.test(architectureShape)) {
-    files.push(`src/jobs/${slug}.job.ts`);
-  }
-
-  if (/audit|review|approval/.test(feature.toLowerCase())) {
-    files.push("src/modules/audit/audit-log.ts");
-  }
-
-  return Array.from(new Set(files));
+  // No pattern matched the selected blueprint: emit a language-aware generic layout.
+  return genericFeatureFiles(feature, architectureShape, stack);
 }
 
 function acceptanceCriteriaForFeature(feature) {
@@ -1956,7 +2047,7 @@ function connectBlocks(tasks) {
   return tasks;
 }
 
-function buildTasks(input, phase, architecture, stackPatterns) {
+function buildTasks(input, phase, architecture, stackPatterns, stack) {
   const tasks = [
     makeTask({
       id: "001",
@@ -2048,7 +2139,7 @@ function buildTasks(input, phase, architecture, stackPatterns) {
         summary: `Design and implement the capability for: ${feature}.`,
         problem: `The product cannot satisfy its initial scope until ${feature} exists as a reviewable, testable capability.`,
         solution: `Add a focused module for ${feature} that matches the recommended ${architecture.shape} and keeps integration boundaries explicit.`,
-        files: featureFiles(feature, architecture.shape, stackPatterns),
+        files: featureFiles(feature, architecture.shape, stackPatterns, stack),
         acceptanceCriteria: acceptanceCriteriaForFeature(feature),
         implementationNotes: [
           "Start from domain rules and access constraints before UI or transport details.",
@@ -2257,7 +2348,7 @@ function buildRisks(input, phase) {
   return risks;
 }
 
-function buildOutput(input, config, playbookContext, repoRoot, inputMetadata) {
+function buildOutput(input, config, playbookContext, repoRoot, inputMetadata, scaffoldkitContext) {
   const phase = inferPhase(input);
   const pathName = inferPath(phase);
   const profile = plannerProfile(input, config);
@@ -2265,7 +2356,19 @@ function buildOutput(input, config, playbookContext, repoRoot, inputMetadata) {
   const options = architectureOptions(input, phase);
   const architecture = architectureRecommendation(options, phase);
   const stackPatterns = loadStackPatterns(repoRoot);
-  const tasks = buildTasks(input, phase, architecture, stackPatterns);
+  // Resolve the scaffold blueprint before building tasks so generated task file
+  // paths match the scaffold's actual stack. scaffoldkitBlueprintRecommendation
+  // only reads architectureRecommendation.shape and plannerProfile from the
+  // output, both known here, so this is the same blueprint the downstream
+  // artifact writers compute for the same inputs (deterministic, no drift).
+  const scaffoldContext = scaffoldkitContext || { root: "", availableBlueprints: [] };
+  const blueprint = scaffoldkitBlueprintRecommendation(
+    input,
+    { architectureRecommendation: architecture, plannerProfile: profile },
+    scaffoldContext
+  ).blueprint;
+  const taskStack = { blueprint, language: blueprintLanguage(blueprint, input) };
+  const tasks = buildTasks(input, phase, architecture, stackPatterns, taskStack);
 
   return {
     projectName: input.projectName,
@@ -2283,6 +2386,7 @@ function buildOutput(input, config, playbookContext, repoRoot, inputMetadata) {
     phase,
     phaseRationale: phaseRationale(input, phase),
     path: pathName,
+    scaffoldBlueprint: blueprint,
     recommendedPlaybooks: recommendedPlaybooks(phase, pathName, playbookContext, repoRoot),
     recommendedGuidanceAreas: recommendedGuidanceAreas(phase, profile, config),
     recommendedArtifacts: recommendedArtifacts(phase, profile, config),
@@ -3352,7 +3456,7 @@ function main() {
 
     const previousRun = loadPreviousRun(workingDir, args.resumeFrom || args.rerunFrom);
     const rerunMode = args.resumeFrom ? "resume" : args.rerunFrom ? "rerun" : "fresh";
-    const output = buildOutput(input, config, playbookContext, planforgeRoot, inputMetadata);
+    const output = buildOutput(input, config, playbookContext, planforgeRoot, inputMetadata, scaffoldkitContext);
     const planforgeIndex = renderPlanforgeIndex(output, {
       specs: args.clarify === true,
       runbooks: shouldWriteRunbooks(output),

--- a/scripts/lib/pattern-matching.js
+++ b/scripts/lib/pattern-matching.js
@@ -76,25 +76,23 @@ function matchPattern(text, patterns) {
   return matches[0];
 }
 
-function resolvePatternFiles(pattern, architectureShape) {
+function resolvePatternFiles(pattern, blueprint) {
   if (!pattern || !pattern.files) {
     return [];
   }
 
-  const shapeKey = String(architectureShape || "")
-    .replace(/\s+/g, "-")
-    .toLowerCase();
-
-  if (pattern.files[shapeKey]) {
-    return pattern.files[shapeKey];
+  const blueprintKey = String(blueprint || "").trim();
+  if (blueprintKey && pattern.files[blueprintKey]) {
+    return pattern.files[blueprintKey];
   }
 
-  if (/next|fullstack/.test(shapeKey) && pattern.files["nextjs-fullstack"]) {
-    return pattern.files["nextjs-fullstack"];
-  }
-
-  const firstShape = Object.keys(pattern.files)[0];
-  return firstShape ? pattern.files[firstShape] : [];
+  // No file set exists for the selected blueprint, so return nothing and let the
+  // caller fall back to a language-aware generic layout. This deliberately drops
+  // the old behavior, which keyed on the architecture *shape* (e.g. "modular
+  // monolith"). A shape string never matched a blueprint key, so the function
+  // always fell through to the first file set — nextjs-fullstack — leaking
+  // Next.js/Prisma paths into every non-Next.js project.
+  return [];
 }
 
 function alignmentScore(actualFiles = [], expectedFiles = []) {

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -225,6 +225,153 @@ runCase("rest/json api intakes select rest-api at strong confidence (the 'cli' s
   assert.equal(scaffoldkit.agentMustCreateStructure, false);
 });
 
+runCase("rest-api feature task paths follow the python/fastapi stack and api-key auth does not leak a Next.js/Prisma template", () => {
+  const fixtureDir = tempDir("planforge-rest-api-task-paths-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "quicklinks-api",
+    summary: "A REST/JSON HTTP API service for shortening URLs. Clients POST a long URL and get back a short code.",
+    targetUsers: ["backend developers", "api consumers"],
+    coreFeatures: [
+      "POST /api/shorten accepting {url} and returning {code, shortUrl} as JSON",
+      "API-key authentication on write endpoints"
+    ],
+    constraints: [
+      "REST/JSON over HTTP only, no server-rendered UI",
+      "PostgreSQL as the system of record"
+    ]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  const outdir = path.join(fixtureDir, "out");
+  const scaffoldkit = readJson(exportsFile(outdir, "scaffoldkit-input.json"));
+  const output = readJson(planningFile(outdir, "plan-output.json"));
+
+  assert.equal(scaffoldkit.blueprint, "rest-api");
+  // The blueprint that drove task generation is recorded in the plan output so
+  // downstream analysis keys off the same stack.
+  assert.equal(output.scaffoldBlueprint, "rest-api");
+
+  const featureTasks = output.tasks.filter((task) => task.category === "feature");
+  const featureFilePaths = featureTasks.flatMap((task) => task.files);
+
+  // Every generated feature file is Python; no .ts/.tsx/.test.js path leaks in.
+  assert.ok(featureFilePaths.length > 0);
+  assert.ok(
+    featureFilePaths.every((file) => !/\.tsx?$|\.test\.js$/.test(file)),
+    `expected only python feature paths, got: ${featureFilePaths.join(", ")}`
+  );
+  assert.ok(featureFilePaths.some((file) => file.endsWith(".py")));
+
+  // Python module names are snake_case identifiers, not the kebab-case slug.
+  const pythonPaths = featureFilePaths.filter((file) => file.endsWith(".py"));
+  assert.ok(
+    pythonPaths.every((file) => !/[a-z0-9]-[a-z0-9]/.test(file)),
+    `python module paths must be snake_case, got: ${pythonPaths.join(", ")}`
+  );
+
+  // The api-key auth task must not splice the canned Next.js/JWT/Prisma user-login template.
+  const authTask = featureTasks.find((task) => /authentication/i.test(task.title));
+  assert.ok(authTask, "expected an authentication feature task");
+  assert.equal(
+    authTask.files.some((file) => /prisma|app\/api\/auth|lib\/auth\/jwt|route\.ts/.test(file)),
+    false,
+    `api-key auth task leaked a Next.js/Prisma template: ${authTask.files.join(", ")}`
+  );
+});
+
+runCase("express-api api-key auth falls back to a generic layout instead of the JWT/user-login template (negativeKeywords guard)", () => {
+  const fixtureDir = tempDir("planforge-express-apikey-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "Ingest Service",
+    summary: "TypeScript backend service for queued workflows and webhooks.",
+    targetUsers: ["internal systems"],
+    coreFeatures: ["webhook ingestion", "API-key authentication on write endpoints"],
+    constraints: ["prefer TypeScript", "must run in Docker"]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  const outdir = path.join(fixtureDir, "out");
+  const scaffoldkit = readJson(exportsFile(outdir, "scaffoldkit-input.json"));
+  const output = readJson(planningFile(outdir, "plan-output.json"));
+  assert.equal(scaffoldkit.blueprint, "express-api");
+
+  // express-api DOES have an authentication-jwt file key, so without the
+  // negativeKeywords guard an api-key task would splice the full JWT/user-login
+  // template. It must instead get the generic (TypeScript) layout.
+  const authTask = output.tasks
+    .filter((task) => task.category === "feature")
+    .find((task) => /authentication/i.test(task.title));
+  assert.ok(authTask, "expected an authentication feature task");
+  assert.equal(
+    authTask.files.some((file) => /auth\/(jwt|password|service|middleware|validation)|routes\/auth|models\/user|register|login|prisma/.test(file)),
+    false,
+    `express-api api-key auth leaked a JWT/user-login template: ${authTask.files.join(", ")}`
+  );
+  assert.ok(authTask.files.some((file) => /\.ts$/.test(file)));
+});
+
+runCase("python cli-tool feature task paths use snake_case python module names", () => {
+  const fixtureDir = tempDir("planforge-python-cli-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "log-tailer",
+    summary: "A command-line developer tool that tails and filters log files.",
+    targetUsers: ["developers"],
+    coreFeatures: ["tail a log file with filtering", "export filtered results to a JSON file"],
+    constraints: ["Python 3.12", "lightweight CLI, no heavy frameworks"]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  const outdir = path.join(fixtureDir, "out");
+  const scaffoldkit = readJson(exportsFile(outdir, "scaffoldkit-input.json"));
+  const output = readJson(planningFile(outdir, "plan-output.json"));
+
+  assert.equal(scaffoldkit.blueprint, "cli-tool");
+  assert.equal(scaffoldkit.suggestedVariables.language, "python");
+  assert.equal(output.scaffoldBlueprint, "cli-tool");
+
+  const featureFilePaths = output.tasks.filter((task) => task.category === "feature").flatMap((task) => task.files);
+  assert.ok(featureFilePaths.length > 0);
+  assert.ok(
+    featureFilePaths.every((file) => file.endsWith(".py")),
+    `expected only python cli paths, got: ${featureFilePaths.join(", ")}`
+  );
+  assert.ok(featureFilePaths.some((file) => /^src\/(commands|core)\//.test(file)));
+  assert.ok(
+    featureFilePaths.every((file) => !/[a-z0-9]-[a-z0-9]/.test(file)),
+    `python module paths must be snake_case, got: ${featureFilePaths.join(", ")}`
+  );
+});
+
+runCase("analyze-artifacts reports clean output for a python rest-api plan", () => {
+  const fixtureDir = tempDir("planforge-analyze-rest-api-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "quicklinks-api",
+    summary: "A REST/JSON HTTP API service for shortening URLs.",
+    targetUsers: ["backend developers"],
+    coreFeatures: [
+      "POST /api/shorten accepting {url} and returning {code, shortUrl} as JSON",
+      "API-key authentication on write endpoints"
+    ],
+    constraints: ["REST/JSON over HTTP only, no server-rendered UI", "PostgreSQL as the system of record"]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  // The analyzer keys alignment scoring on scaffoldBlueprint; for a keyless
+  // blueprint (rest-api) it must degrade cleanly, not raise spurious criticals.
+  const analysis = runAnalyzer(["--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(analysis.status, 0, analysis.stderr);
+  const report = readText(path.join(fixtureDir, "out", "outputs", "consistency-report.md"));
+  assert.match(report, /Critical issues: 0/);
+});
+
 runCase("git-backed cli sync plans stay on cli-tool semantics and avoid database defaults", () => {
   const fixtureDir = tempDir("planforge-cli-sync-");
   writeJson(path.join(fixtureDir, "input.json"), {
@@ -312,6 +459,17 @@ runCase("php symfony backend plans recommend the symfony backend blueprint", () 
   assert.equal(scaffoldkit.suggestedVariables.database, "postgresql");
   assert.equal(Object.prototype.hasOwnProperty.call(scaffoldkit.suggestedVariables, "language"), false);
   assert.equal(Object.prototype.hasOwnProperty.call(scaffoldkit.suggestedVariables, "cli_framework"), false);
+
+  // PHP blueprint -> PHP feature task paths (PascalCase classes), not TypeScript.
+  const output = readJson(planningFile(path.join(fixtureDir, "out"), "plan-output.json"));
+  assert.equal(output.scaffoldBlueprint, "symfony-backend");
+  const phpFeatureFiles = output.tasks.filter((task) => task.category === "feature").flatMap((task) => task.files);
+  assert.ok(phpFeatureFiles.length > 0);
+  assert.ok(
+    phpFeatureFiles.every((file) => file.endsWith(".php")),
+    `expected php feature paths, got: ${phpFeatureFiles.join(", ")}`
+  );
+  assert.ok(phpFeatureFiles.some((file) => /^src\/(Controller|Service|Repository)\/.+\.php$/.test(file)));
 });
 
 runCase("php symfony plus react dashboard plans recommend the symfony nextjs blueprint", () => {


### PR DESCRIPTION
## What

Generated feature-task file paths now match the selected scaffold blueprint's stack instead of being hardcoded TypeScript.

## Why

r5 dogfood (dogfood-quicklinks-r5): after the blueprint-selection fix (#80), a REST/JSON intake correctly selects rest-api with a coherent FastAPI/uvicorn scaffold, but the generated feature TASK paths were still TypeScript (`src/modules/*.ts`, `tests/integration/*.test.js`) and the "API-key authentication" task spliced a full Next.js/JWT/bcrypt/Zod/Prisma user-login template. That was the last remaining stack-contradiction axis from the r5 dogfood.

## Root cause

`resolvePatternFiles(pattern, architectureShape)` keyed on the architecture shape (e.g. "modular monolith"), which never matches a blueprint-keyed file set in `stack-patterns.json`. So it always fell through to the first set, `nextjs-fullstack`, leaking Next.js/Prisma paths into every non-Next.js project. The generic fallback hardcoded TypeScript.

## Change

- `resolvePatternFiles` keys on the selected blueprint; returns `[]` when no file set exists so the caller uses a language-aware generic layout.
- `bootstrap-plan` resolves the blueprint up front (deterministic; reads only `architectureRecommendation.shape` and `plannerProfile`, the same signals the downstream writers use) and records `plan-output.scaffoldBlueprint`; threads `{blueprint, language}` into task generation.
- `genericFeatureFiles` emits python (snake_case modules), php (PascalCase classes), or typescript (modular) layouts.
- `authentication-jwt` gains `negativeKeywords` (api key/apikey/api token); the git-memory-sync short-circuit is gated on a TS stack.
- `analyze-artifacts` scores alignment against the recorded blueprint.

## Verification

- 26 CLI + 47 server tests green; both CI generation smokes pass.
- Live: a rest-api intake now emits fully Python task paths with no Next.js/Prisma leak; a nextjs-fullstack project is byte-identical to before.

## Scope notes

- Curated `stack-patterns.json` file sets now apply only to blueprints with a matching key (nextjs-fullstack, express-api, reference-php-app). nextjs-frontend and saas-dashboard now get the generic TypeScript layout instead of the nextjs-fullstack set; intentional, and stays coherent TypeScript.
- The score-based mismatch check in analyze-artifacts is a no-op for blueprints without pattern keys (rest-api/cli-tool/symfony-*); the primary cross-pattern path still applies.

Refs: agent-tasks 520b431f