### PR TITLE
chore(deps): bump SCAFFOLDKIT_REF to 587fd46

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -45,11 +45,12 @@ RUN cd server && npm run build
 # and the venv's python3 binary would fail at runtime with
 # `cannot open shared object file: libpython3.12.so.1.0`.
 FROM python:3.11-slim AS scaffoldkit
-# Pinned to https://github.com/LanNguyenSi/scaffoldkit @ 59ccd5b (2026-05).
+# Pinned to https://github.com/LanNguyenSi/scaffoldkit @ 587fd46 (2026-06).
 # Update this when bumping scaffoldkit; image build will pull a fresh
-# clone and rebuild the venv. 59ccd5b adds the --no-ai-context flag that
-# generate.ts passes, so scaffoldkit no longer clobbers planforge's .ai/.
-ARG SCAFFOLDKIT_REF=59ccd5b
+# clone and rebuild the venv. 587fd46 makes the rest-api (fastapi) and
+# cli-tool (python) blueprints emit real, runnable starter source
+# (src/main.py + an example route/command + a smoke test) instead of an empty src/.
+ARG SCAFFOLDKIT_REF=587fd46
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y git ca-certificates \


### PR DESCRIPTION
## What

Bump `SCAFFOLDKIT_REF` `59ccd5b` -> `587fd46` in `server/Dockerfile` (+ refresh the pin comment).

## Why

`587fd46` is scaffoldkit master HEAD after PR #48 (task 6fafaaad): the rest-api (fastapi) and cli-tool (python) blueprints now emit real, runnable starter source instead of an empty `src/`. The planforge image clones scaffoldkit at this pin, so bumping it and rebuilding makes those starters live in the deployed planforge HTTP service and project-forge. Pairs with #81 (blueprint-aware task paths), which ships via the sibling build context. The pin stays a specific SHA (no floating main).

## Verification

- `587fd46` = `LanNguyenSi/scaffoldkit` master HEAD (PR #48 squash merge).
- The planforge docker-build CI job builds the image against the new ref.
- Followed by a VPS-01 redeploy + R6 dogfood (separate step).

Refs: agent-tasks b5e0cce1