### PR TITLE
fix(tasks): make the coverage task test paths follow the selected stack

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -1970,6 +1970,33 @@ function genericFeatureFiles(feature, architectureShape, stack) {
   return Array.from(new Set(files));
 }
 
+// Coverage/quality task test paths, chosen for the selected blueprint's language
+// so the hardening task stays coherent with the scaffold (a FastAPI rest-api gets
+// pytest paths, not hardcoded .test.js). Mirrors genericFeatureFiles' language switch.
+function coverageTaskFiles(stack) {
+  const language = (stack && stack.language) || "typescript";
+  if (language === "python") {
+    return [
+      "tests/integration/test_critical_path.py",
+      "tests/integration/test_error_handling.py",
+      "tests/contract/test_integrations.py"
+    ];
+  }
+  if (language === "php") {
+    return [
+      "tests/Integration/CriticalPathTest.php",
+      "tests/Integration/ErrorHandlingTest.php",
+      "tests/Contract/IntegrationsTest.php"
+    ];
+  }
+  // TypeScript (default): match the .test.ts convention used elsewhere in this file.
+  return [
+    "tests/integration/critical-path.test.ts",
+    "tests/integration/error-handling.test.ts",
+    "tests/contract/integrations.test.ts"
+  ];
+}
+
 function featureFiles(feature, architectureShape, stackPatterns, stack) {
   // The git-memory-sync layout is TypeScript-specific, so only short-circuit for
   // a TypeScript (or unspecified) stack; other languages fall through to the
@@ -2164,11 +2191,7 @@ function buildTasks(input, phase, architecture, stackPatterns, stack) {
       summary: "Verify the critical path, failure handling, and integration boundaries with tests.",
       problem: "The initial implementation backlog leaves room for silent regressions unless critical-path and error-path coverage are added deliberately.",
       solution: "Add end-to-end and integration-focused verification around the user path, external boundaries, and failure handling assumptions.",
-      files: [
-        "tests/integration/critical-path.test.js",
-        "tests/integration/error-handling.test.js",
-        "tests/contract/integrations.test.js"
-      ],
+      files: coverageTaskFiles(stack),
       acceptanceCriteria: [
         "Critical path behavior is exercised through automated tests.",
         "Integration and error paths fail loudly instead of degrading silently.",

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -279,6 +279,22 @@ runCase("rest-api feature task paths follow the python/fastapi stack and api-key
     false,
     `api-key auth task leaked a Next.js/Prisma template: ${authTask.files.join(", ")}`
   );
+
+  // The hardening/coverage (quality) task must also follow the stack, not hardcode .test.js.
+  const coverageTask = output.tasks.find((task) => task.category === "quality");
+  assert.ok(coverageTask, "expected a quality coverage task");
+  assert.ok(
+    coverageTask.files.every((file) => !/\.test\.js$/.test(file)),
+    `coverage task leaked JS test paths: ${coverageTask.files.join(", ")}`
+  );
+  assert.ok(
+    coverageTask.files.every((file) => file.endsWith(".py")),
+    `coverage task should emit Python test paths, got: ${coverageTask.files.join(", ")}`
+  );
+  assert.ok(
+    coverageTask.files.some((file) => /tests\/integration\/test_/.test(file)),
+    `coverage task should use pytest integration paths, got: ${coverageTask.files.join(", ")}`
+  );
 });
 
 runCase("express-api api-key auth falls back to a generic layout instead of the JWT/user-login template (negativeKeywords guard)", () => {
@@ -312,6 +328,18 @@ runCase("express-api api-key auth falls back to a generic layout instead of the 
     `express-api api-key auth leaked a JWT/user-login template: ${authTask.files.join(", ")}`
   );
   assert.ok(authTask.files.some((file) => /\.ts$/.test(file)));
+
+  // Negative control: the TS stack's coverage task keeps .test.ts, no regression to .test.js.
+  const coverageTask = output.tasks.find((task) => task.category === "quality");
+  assert.ok(coverageTask, "expected a quality coverage task");
+  assert.ok(
+    coverageTask.files.every((file) => !/\.test\.js$/.test(file)),
+    `coverage task regressed to JS test paths: ${coverageTask.files.join(", ")}`
+  );
+  assert.ok(
+    coverageTask.files.every((file) => /\.test\.ts$/.test(file)),
+    `coverage task should emit .test.ts for a TS stack, got: ${coverageTask.files.join(", ")}`
+  );
 });
 
 runCase("python cli-tool feature task paths use snake_case python module names", () => {


### PR DESCRIPTION
## What

The "Add integration and error-handling coverage" quality task in `buildTasks` hardcoded `.test.js` test paths regardless of the selected blueprint, so a Python/FastAPI rest-api emitted JavaScript test paths in an otherwise pure-pytest project. This is the gap #81 left: it made feature tasks stack-aware but not this hardcoded quality task, which lives on a separate code path.

## Change

- `coverageTaskFiles(stack)` mirrors `genericFeatureFiles`' python/php/typescript switch, threading the `{blueprint, language}` already passed into `buildTasks`.
- Python emits pytest paths, php emits PascalCase class tests, and the default TypeScript path uses `.test.ts` to match the rest of the file.
- Tests: the python rest-api coverage task emits no `.test.js` and uses pytest paths; a TypeScript negative control confirms the default stays `.test.ts`.

## Verification

`npm run test:cli` green (all CLI tests pass). Review subagent verdict: SHIP, no must-fix.

Refs: agent-tasks 6c5eda2c