### PR TITLE
fix(output): reference playbooks as stable URLs, not dangling filesystem paths

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -1126,11 +1126,21 @@ function loadScaffoldkitContext(repoRoot) {
   };
 }
 
-function resolvePlaybookPath(playbookContext, relativePath) {
-  if (playbookContext.root) {
-    return path.join(playbookContext.root, relativePath);
-  }
-  return path.join("agent-engineering-playbook", relativePath);
+// Playbooks are referenced from generated deliverables as stable GitHub URLs, not
+// filesystem paths: the playbook files are never copied into the generated repo, so
+// a relative path dangles for the consumer and an absolute path leaks the planforge
+// container's /app working dir. planning-and-scoping ships in this repo; the phase
+// playbooks live in the external agent-engineering-playbook library.
+const PLANFORGE_PLAYBOOK_URL =
+  "https://github.com/LanNguyenSi/agent-planforge/blob/main/playbooks/planning-and-scoping.md";
+const ENGINEERING_PLAYBOOK_BASE =
+  "https://github.com/LanNguyenSi/agent-engineering-playbook/blob/main";
+
+function resolvePlaybookPath(relativePath) {
+  // Always emit a stable external URL. A local/absolute filesystem path (the prior
+  // behavior) either dangled for the consumer or leaked the container filesystem,
+  // since the playbook files are never copied into the deliverable.
+  return `${ENGINEERING_PLAYBOOK_BASE}/${relativePath}`;
 }
 
 function inferPhase(input) {
@@ -1310,22 +1320,22 @@ function phaseRationale(input, phase) {
   return reasons;
 }
 
-function recommendedPlaybooks(phase, pathName, playbookContext, repoRoot) {
+function recommendedPlaybooks(phase, pathName, playbookContext) {
   const mandatory = [];
   const adoptionModel = playbookContext.model || {};
   const corePhases = (((adoptionModel.paths || {}).core || {}).mandatory_playbooks_by_phase) || {};
   const enterprisePhases = (((adoptionModel.paths || {}).enterprise || {}).mandatory_playbooks_by_phase) || {};
   const baselinePhase = phase === "phase_3" ? "phase_2" : phase;
 
-  mandatory.push(path.join(repoRoot, "playbooks", "planning-and-scoping.md"));
+  mandatory.push(PLANFORGE_PLAYBOOK_URL);
 
   (corePhases[baselinePhase] || []).forEach((relativePath) => {
-    mandatory.push(resolvePlaybookPath(playbookContext, relativePath));
+    mandatory.push(resolvePlaybookPath(relativePath));
   });
 
   if (pathName === "enterprise") {
     (enterprisePhases.phase_3 || []).forEach((relativePath) => {
-      mandatory.push(resolvePlaybookPath(playbookContext, relativePath));
+      mandatory.push(resolvePlaybookPath(relativePath));
     });
   }
 
@@ -2410,7 +2420,7 @@ function buildOutput(input, config, playbookContext, repoRoot, inputMetadata, sc
     phaseRationale: phaseRationale(input, phase),
     path: pathName,
     scaffoldBlueprint: blueprint,
-    recommendedPlaybooks: recommendedPlaybooks(phase, pathName, playbookContext, repoRoot),
+    recommendedPlaybooks: recommendedPlaybooks(phase, pathName, playbookContext),
     recommendedGuidanceAreas: recommendedGuidanceAreas(phase, profile, config),
     recommendedArtifacts: recommendedArtifacts(phase, profile, config),
     architectureOptions: options,

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -107,6 +107,26 @@ runCase("sample input generates enterprise artifacts and downstream exports", ()
   assert.equal(output.inputFormat, "json");
   assert.ok(output.recommendedPlaybooks.some((entry) => entry.endsWith("playbooks/05-development-workflow.md")));
   assert.ok(output.recommendedPlaybooks.some((entry) => entry.endsWith("playbooks/10-security-and-governance.md")));
+
+  // Playbook references must be deliverable-safe: stable external URLs, never a
+  // local/absolute filesystem path (which dangles for the consumer or leaks the
+  // planforge container's /app working dir). Regression guard for the prior
+  // /app/playbooks and bare agent-engineering-playbook/ filesystem refs.
+  assert.ok(
+    output.recommendedPlaybooks.every((entry) => /^https:\/\//.test(entry)),
+    `recommendedPlaybooks must be https URLs, got: ${output.recommendedPlaybooks.join(", ")}`
+  );
+  assert.ok(
+    output.recommendedPlaybooks.every((entry) => !entry.startsWith("/") && !entry.includes("/app/")),
+    `recommendedPlaybooks leaked an absolute/container path: ${output.recommendedPlaybooks.join(", ")}`
+  );
+  assert.ok(!agentsDoc.includes("/app/playbooks"), "agents doc leaked the container /app/playbooks path");
+  assert.doesNotMatch(agentsDoc, /^- agent-engineering-playbook\/playbooks\//m);
+  assert.ok(
+    agentsDoc.includes("https://github.com/LanNguyenSi/agent-planforge/blob/main/playbooks/planning-and-scoping.md"),
+    "agents doc should reference planning-and-scoping as a resolvable URL"
+  );
+
   assert.ok(output.tasks.every((task) => Array.isArray(task.acceptanceCriteria) && task.acceptanceCriteria.length > 0));
 
   assert.match(projectIndex, /# PROJECT: Vendor Access Hub/);


### PR DESCRIPTION
## Problem

Generated deliverables listed "Applicable Playbooks" as filesystem paths that never resolve for a consumer:
- `planning-and-scoping.md` was emitted via `path.join(repoRoot, ...)`, which in the planforge container becomes the absolute `/app/playbooks/planning-and-scoping.md`, leaking the container working directory into the published repo.
- The per-phase playbooks were emitted as bare `agent-engineering-playbook/playbooks/NN-*.md`, a sibling library never copied into the deliverable, so an agent told to "follow the applicable playbooks listed below" found zero of them locally.

This is the same dangling-reference class #79 fixed for the runner/handoff exhaust, in a different set of files.

## Change

- Both refs now emit stable GitHub URLs. `planning-and-scoping` resolves in this public repo; the phase playbooks point at the external `agent-engineering-playbook` library (already the canonical reference in this repo's README ecosystem table).
- `resolvePlaybookPath` no longer branches on a local sibling checkout, so the emitted list is deliverable-safe whether or not `AGENT_ENGINEERING_PLAYBOOK_ROOT` is set.
- The refs only feed the emitted `recommendedPlaybooks` list (docs, `planforge-index.json`, a count), never file reads, so the format change is contained.

## Note on the external repo

`agent-engineering-playbook` is currently a private/unpublished org repo (GitHub API returns 404 publicly), so its blob URLs resolve for org members, the actual consumers. This is strictly better than the prior bug, a dangling relative path that any consuming agent would try to open as a local file. If the playbooks should be public, the follow-up is a one-line `ENGINEERING_PLAYBOOK_BASE` change or publishing the repo.

## Verification

`npm run test:cli` green. Fresh generation confirmed no `/app/playbooks` and no bare `agent-engineering-playbook/` FS ref; all playbook refs are https URLs. New tests assert every `recommendedPlaybooks` entry is an https URL with no absolute or `/app` path, and the rendered `.ai/AGENTS.md` drops the leak. Review subagent: SHIP, no must-fix.

Refs: agent-tasks dead4af7