### PR TITLE
chore(deps): bump SCAFFOLDKIT_REF to d2739c2

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -45,12 +45,13 @@ RUN cd server && npm run build
 # and the venv's python3 binary would fail at runtime with
 # `cannot open shared object file: libpython3.12.so.1.0`.
 FROM python:3.11-slim AS scaffoldkit
-# Pinned to https://github.com/LanNguyenSi/scaffoldkit @ 587fd46 (2026-06).
+# Pinned to https://github.com/LanNguyenSi/scaffoldkit @ d2739c2 (2026-06).
 # Update this when bumping scaffoldkit; image build will pull a fresh
-# clone and rebuild the venv. 587fd46 makes the rest-api (fastapi) and
-# cli-tool (python) blueprints emit real, runnable starter source
-# (src/main.py + an example route/command + a smoke test) instead of an empty src/.
-ARG SCAFFOLDKIT_REF=587fd46
+# clone and rebuild the venv. d2739c2 adds a minimal runnable starter to the
+# fastapi-backend blueprint (the planforge remap target for python-hint REST
+# intakes), on top of 587fd46's rest-api (fastapi) and cli-tool (python)
+# starters (src/main.py + an example route/command + a smoke test).
+ARG SCAFFOLDKIT_REF=d2739c2
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y git ca-certificates \


### PR DESCRIPTION
Bump `ARG SCAFFOLDKIT_REF` in `server/Dockerfile` from `587fd46` to `d2739c2` (scaffoldkit master HEAD after #49). The planforge image clones scaffoldkit at this ref, so the bump makes the new fastapi-backend minimal starter live in the deployed planforge HTTP service and project-forge, for the python-hint REST intakes that remap to `fastapi-backend`.

Without the bump, a VPS redeploy rebuilds the planforge image against the old pin and the scaffoldkit fix (#49 / agent-tasks e3cf37c2) never goes live.

Specific-SHA pin preserved (no floating main), per ADR-0002. Verified: `d2739c2` is scaffoldkit `origin/master` HEAD (the #49 merge). Review subagent: SHIP.

Refs: agent-tasks 7c5f3472