### PR TITLE
fix(tasks): make the foundation task manifest follow the selected stack

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -2007,6 +2007,20 @@ function coverageTaskFiles(stack) {
   ];
 }
 
+// The primary manifest a freshly scaffolded repo carries, by language, so the
+// foundation "set up repository" task does not hardcode a Node package.json into
+// a python/php project.
+function manifestFileForStack(stack) {
+  const language = (stack && stack.language) || "typescript";
+  if (language === "python") {
+    return "pyproject.toml";
+  }
+  if (language === "php") {
+    return "composer.json";
+  }
+  return "package.json";
+}
+
 function featureFiles(feature, architectureShape, stackPatterns, stack) {
   // The git-memory-sync layout is TypeScript-specific, so only short-circuit for
   // a TypeScript (or unspecified) stack; other languages fall through to the
@@ -2124,7 +2138,7 @@ function buildTasks(input, phase, architecture, stackPatterns, stack) {
       problem: "Execution work will fragment quickly if the repository, quality gates, and documentation expectations are not defined up front.",
       solution: "Establish the test path, delivery workflow expectations, and starter documentation before feature branches accumulate drift.",
       files: [
-        "package.json",
+        manifestFileForStack(stack),
         "README.md",
         "tests/",
         ".github/workflows/"

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -315,6 +315,19 @@ runCase("rest-api feature task paths follow the python/fastapi stack and api-key
     coverageTask.files.some((file) => /tests\/integration\/test_/.test(file)),
     `coverage task should use pytest integration paths, got: ${coverageTask.files.join(", ")}`
   );
+
+  // The foundation "set up repository" task's manifest must follow the stack, not
+  // hardcode a Node package.json into a python project.
+  const setupTask = output.tasks.find((task) => /set up repository/i.test(task.title));
+  assert.ok(setupTask, "expected a 'set up repository' foundation task");
+  assert.ok(
+    setupTask.files.includes("pyproject.toml"),
+    `setup task should list pyproject.toml, got: ${setupTask.files.join(", ")}`
+  );
+  assert.ok(
+    !setupTask.files.includes("package.json"),
+    `setup task leaked package.json into a python project: ${setupTask.files.join(", ")}`
+  );
 });
 
 runCase("express-api api-key auth falls back to a generic layout instead of the JWT/user-login template (negativeKeywords guard)", () => {
@@ -359,6 +372,14 @@ runCase("express-api api-key auth falls back to a generic layout instead of the 
   assert.ok(
     coverageTask.files.every((file) => /\.test\.ts$/.test(file)),
     `coverage task should emit .test.ts for a TS stack, got: ${coverageTask.files.join(", ")}`
+  );
+
+  // Negative control: the TS stack's setup task keeps package.json.
+  const setupTask = output.tasks.find((task) => /set up repository/i.test(task.title));
+  assert.ok(setupTask, "expected a 'set up repository' foundation task");
+  assert.ok(
+    setupTask.files.includes("package.json"),
+    `TS setup task should list package.json, got: ${setupTask.files.join(", ")}`
   );
 });
 


### PR DESCRIPTION
## Problem

The "Set up repository and delivery baseline" foundation task (002) hardcoded `package.json` in its `files`, so a python/php repo was told to create a Node manifest. Same gap as the coverage task (#83): a hardcoded buildTasks template ignoring the resolved `{blueprint, language}` stack. Surfaced by the r7 dogfood (canMakeProgress=true, so non-blocking).

## Change

- `manifestFileForStack(stack)` returns `pyproject.toml` for python, `composer.json` for php, `package.json` for the default TypeScript/node stack. Mirrors `coverageTaskFiles` from #83.
- Tests: the python rest-api setup task lists `pyproject.toml` and no `package.json`; a TypeScript negative control keeps `package.json`.

## Verification

`npm run test:cli` green. Review subagent: SHIP, no must-fix (confirmed 002 is the only remaining stack-specific hardcode in buildTasks).

Refs: agent-tasks 1b4e0946