### PR TITLE
chore(release): agent-planforge v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-01
+
+### Changed
+
+- The bundled scaffoldkit is pinned to v0.3.0: real runnable starters for the
+  `rest-api`, `cli-tool`, and `fastapi-backend` blueprints (the last unified on
+  the `src/` layout), so generated repositories open with runnable source
+  instead of an empty `src/`.
+
+### Fixed
+
+- Generated task file paths and manifests now follow the selected blueprint's
+  language. The feature tasks, the integration/error-handling coverage task, and
+  the "set up repository" foundation task emit Python (pytest, `pyproject.toml`),
+  PHP, or TypeScript/Node paths to match the scaffold, instead of hardcoding
+  `.test.js` and `package.json` into every plan.
+- Blueprint selection word-boundaries the CLI detector and adds a dedicated
+  REST/HTTP-API branch, so a REST/JSON intake selects `rest-api` instead of
+  being misrouted to `cli-tool` by a stray "cli" substring.
+- Recommended-playbook references are emitted as stable GitHub URLs instead of
+  filesystem paths, fixing a container-absolute `/app/playbooks/...` leak and
+  dangling `agent-engineering-playbook/...` references in the generated `.ai/`
+  and `.planforge/docs` artifacts.
+- Generated `AGENTS.md` and `PROJECT.md` no longer reference the removed
+  runner/handoff artifacts.
+
 ### Removed
 
 - Stopped emitting the write-only runner/handoff orchestration artifacts from

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-planforge",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Planning bootstrap for agentic architecture and task generation",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Cut agent-planforge **v0.4.0** (from v0.3.0).

## Changes since v0.3.0

- **Removed** the write-only runner/handoff orchestration fleet from generated output (#78)
- **Fixed** generated task file paths and manifests to follow the selected blueprint's language (Python/PHP/Node) instead of hardcoding `.test.js` / `package.json` (#81, #83, #86)
- **Fixed** blueprint selection: word-boundary the CLI detector plus a dedicated REST/HTTP-API branch, so a REST intake is not misrouted to `cli-tool` (#80)
- **Fixed** recommended-playbook references to stable GitHub URLs, no `/app/playbooks` container leak or dangling sibling-repo paths (#84)
- **Fixed** generated `AGENTS.md` / `PROJECT.md` dangling runner/handoff references (#79)
- **Changed** the bundled scaffoldkit pin to v0.3.0, runnable starters plus the fastapi-backend `src/` layout (#82, #85, #87)

## Verification

`npm test` (69 tests: CLI plus server) green. Dogfooded end-to-end on the live stack (r6/r7/r8 generated repos, fresh-implementer `canMakeProgress=true`). Review subagent: SHIP.

Tagging `v0.4.0` after merge triggers the release workflow (CI + GitHub Release).

Refs: agent-tasks 28de9c60