### PR TITLE
drop(reference-php-app): remove from selector and fix generic-PHP footgun

### DIFF
--- a/config/stack-patterns.json
+++ b/config/stack-patterns.json
@@ -711,16 +711,7 @@
     },
     "php-symfony": {
       "keywords": ["php", "symfony", "laravel", "composer", "artisan", "phpunit", "phpstan"],
-      "files": {
-        "reference-php-app": [
-          "build/app/Dockerfile — PHP-FPM container build for the application runtime",
-          "build/nginx/Dockerfile — nginx container build for frontend serving and proxying",
-          "docker-compose.yml — Local orchestration for php-fpm, nginx, and database services",
-          "tools/composer.json — PHP dependency and quality-tooling manifest",
-          "phpunit.xml.dist — PHPUnit test suite configuration",
-          "phpstan.neon.dist — PHPStan static analysis configuration"
-        ]
-      }
+      "files": {}
     }
   }
 }

--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -1672,19 +1672,19 @@ function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
 
   if (/\b(php|symfony|laravel|composer|artisan|phpunit|phpstan)\b/.test(combinedText)) {
     if (/(next\.?js|react|vue|angular|frontend|spa|client-side)/.test(combinedText)) {
-      candidates = ["symfony-nextjs", "reference-php-app"];
+      candidates = ["symfony-nextjs", "symfony-backend"];
       reason = "PHP/Symfony + JS frontend signals -> symfony-nextjs";
       confidence = "strong";
     } else if (
       /(api|rest|json endpoint|backend|service|graphql)/.test(combinedText) &&
       !/(frontend|portal|admin ui|dashboard)/.test(combinedText)
     ) {
-      candidates = ["symfony-backend", "reference-php-app"];
+      candidates = ["symfony-backend"];
       reason = "PHP/Symfony backend/API without frontend -> symfony-backend";
       confidence = "strong";
     } else {
-      candidates = ["reference-php-app", "symfony-backend"];
-      reason = "Generic PHP/Symfony -> reference-php-app as baseline";
+      candidates = ["symfony-backend"];
+      reason = "Generic PHP/Symfony -> symfony-backend as baseline";
       confidence = "medium";
       manualStructureReason = "The framework family is clear, but the generated scaffold may still need manual adaptation for the final repository layout.";
     }
@@ -1782,7 +1782,6 @@ function blueprintLanguage(blueprint, input) {
     case "cli-tool":
       // language = typescript when the constraints ask for it, otherwise python (typer).
       return /typescript/.test(constraintsText) ? "typescript" : "python";
-    case "reference-php-app":
     case "symfony-backend":
     case "symfony-nextjs":
       // symfony-nextjs is a PHP backend with a Next.js frontend; feature task
@@ -1835,8 +1834,6 @@ function scaffoldkitSuggestedVariables(input, output, blueprint) {
     suggested.config_format = "json";
     suggested.distribution = suggested.language === "typescript" ? "binary" : "pip-package";
     suggested.description = input.summary || "A developer-facing automation tool";
-  } else if (blueprint === "reference-php-app") {
-    suggested.use_docker = /docker|container|compose/.test(combinedText);
   } else if (blueprint === "symfony-backend") {
     suggested.php_version = /php 8\.2/.test(constraintsText) ? "8.2" : "8.3";
     suggested.symfony_version = inferSymfonyVersion(input);
@@ -3321,7 +3318,7 @@ function shouldWriteRuntimeTemplates(input, output, outdir) {
     return false;
   }
 
-  if (["reference-php-app", "symfony-backend", "symfony-nextjs"].includes(blueprint)) {
+  if (["symfony-backend", "symfony-nextjs"].includes(blueprint)) {
     return false;
   }
 

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -541,6 +541,36 @@ runCase("php symfony backend plans recommend the symfony backend blueprint", () 
   assert.ok(phpFeatureFiles.some((file) => /^src\/(Controller|Service|Repository)\/.+\.php$/.test(file)));
 });
 
+runCase("generic php/symfony plans recommend symfony-backend, not the removed reference shell", () => {
+  const fixtureDir = tempDir("planforge-php-generic-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "Internal Records",
+    summary: "A PHP application built with Symfony for an internal records workflow.",
+    targetUsers: ["internal staff"],
+    coreFeatures: [
+      "Symfony application skeleton",
+      "composer dependency management",
+      "phpunit test coverage"
+    ],
+    constraints: ["PHP 8.3", "Symfony 7"]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  // Generic PHP intake (no api/backend or frontend signal) hits the baseline branch,
+  // which used to return the app-less reference-php-app shell. It must now pick the
+  // runnable symfony-backend instead.
+  const scaffoldkit = readJson(exportsFile(path.join(fixtureDir, "out"), "scaffoldkit-input.json"));
+  assert.equal(scaffoldkit.blueprint, "symfony-backend");
+  assert.equal(scaffoldkit.blueprintConfidence, "medium");
+  assert.match(scaffoldkit.blueprintReason, /symfony-backend as baseline/);
+  assert.ok(
+    !scaffoldkit.blueprintCandidates.includes("reference-php-app"),
+    `reference-php-app should be gone, got: ${scaffoldkit.blueprintCandidates.join(", ")}`
+  );
+});
+
 runCase("php symfony plus react dashboard plans recommend the symfony nextjs blueprint", () => {
   const fixtureDir = tempDir("planforge-php-symfony-nextjs-");
   writeJson(path.join(fixtureDir, "input.json"), {


### PR DESCRIPTION
## What
Companion to scaffoldkit's `reference-php-app` removal (scaffoldkit#61). The blueprint no longer exists, so this removes every planforge reference to it and fixes the selector footgun it caused.

## Changes
- `bootstrap-plan.js`: drop `reference-php-app` from the PHP selector candidate lists (Branch A/B), the `blueprintLanguage` switch, the `scaffoldkitSuggestedVariables` branch, and the `shouldWriteRuntimeTemplates` suppression list.
- Generic PHP/Symfony intake (Branch C) previously returned the app-less `reference-php-app` shell ahead of the runnable `symfony-backend`; it now selects `symfony-backend` as the baseline.
- `config/stack-patterns.json`: drop the `reference-php-app` key from the `php-symfony` files map (surviving blueprints already fall through to the language-aware generic layout).
- New test: generic PHP/Symfony intake selects `symfony-backend` and never `reference-php-app`.

## Verification
`npm run test:cli` + `test:server` green (incl. the new assertion); no residual `reference-php-app` references.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md