### PR TITLE
release: agent-planforge v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-02
+
+### Changed
+
+- Bumped the bundled scaffoldkit pin to v0.4.0, which ships runnable starter code for every remaining blueprint and removes the app-less `reference-php-app` blueprint.
+- The PHP/Symfony selector no longer offers `reference-php-app`; generic PHP/Symfony intake now selects the runnable `symfony-backend` as its baseline instead of an empty ops-shell ([#89](https://github.com/LanNguyenSi/agent-planforge/pull/89)).
+
+### Removed
+
+- Dropped all `reference-php-app` references from the blueprint selector, the `blueprintLanguage` map, the suggested-variables logic, the runtime-template suppression list, and the `php-symfony` stack-pattern files map ([#89](https://github.com/LanNguyenSi/agent-planforge/pull/89)).
+
 ## [0.4.0] - 2026-06-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-planforge",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Planning bootstrap for agentic architecture and task generation",
   "license": "MIT",
   "keywords": [

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -50,7 +50,7 @@ FROM python:3.11-slim AS scaffoldkit
 # clone and rebuild the venv. f52acba unifies the fastapi-backend blueprint on the
 # src/ layout (app/ -> src/, app/api/routes/ -> src/routes/) so the scaffold matches
 # the planner's task paths, on top of d2739c2's fastapi-backend starter source.
-ARG SCAFFOLDKIT_REF=f52acba
+ARG SCAFFOLDKIT_REF=26d9ce1ac54eecb5989c4e5c762b84c703615125
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y git ca-certificates \


### PR DESCRIPTION
## Release agent-planforge v0.5.0

### Highlights
- Bundled scaffoldkit pinned to **v0.4.0**: runnable starter code for every remaining blueprint, and the app-less `reference-php-app` blueprint removed.
- PHP/Symfony selector cleanup: generic PHP intake now selects the runnable `symfony-backend` instead of the dropped ops-shell (footgun fixed, #89).

### Mechanics
- Version 0.4.0 to 0.5.0 (root `package.json`).
- `server/Dockerfile` `SCAFFOLDKIT_REF` `f52acba` to `26d9ce1ac54eecb5989c4e5c762b84c703615125` (scaffoldkit v0.4.0).
- CHANGELOG `[Unreleased]` to `[0.5.0]`.
- `test:cli` + `test:server` (47) green.

The `v0.5.0` tag is pushed after merge to trigger the release workflow.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md