### PR TITLE
security: bump hono to ^4.12.23 (4 MEDIUM CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-planforge",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-planforge",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
-        "hono": "^4.7.9",
+        "hono": "^4.12.23",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -1129,9 +1129,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.1",
-    "hono": "^4.7.9",
+    "hono": "^4.12.23",
     "zod": "^3.24.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump `hono` in `server/` from `^4.7.9` (resolved 4.12.18) to `^4.12.23` to patch four MEDIUM-severity CVEs first fixed in hono 4.12.21.

### CVEs fixed

- **CVE-2026-47673** (GHSA-f577-qrjj-4474) — patched in hono 4.12.21
- **CVE-2026-47674** (GHSA-xrhx-7g5j-rcj5) — patched in hono 4.12.21
- **CVE-2026-47675** (GHSA-3hrh-pfw6-9m5x) — patched in hono 4.12.21
- **CVE-2026-47676** (GHSA-2gcr-mfcq-wcc3) — patched in hono 4.12.21

### Verification

- `npm audit`: 0 advisories (both root and server)
- Build: `tsc` in `server/` passes clean
- Tests: 2 test files, 47 tests passed (vitest); 28 CLI integration tests passed
- Diff: only `server/package.json`, `server/package-lock.json`, `package-lock.json` changed; no source files touched
- Major version: stays on hono 4.x (4.12.18 → 4.12.23)

Refs: depsight CVE scan 2026-06-06