### PR TITLE
fix(security): remediate MEDIUM audit findings (#47)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,11 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Extract changelog for this version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          awk '/^## \[${{ steps.version.outputs.version }}\]/{found=1; next} /^## \[/{found=0} found' CHANGELOG.md > release_notes.md
-          echo "Release notes extracted for v${{ steps.version.outputs.version }}"
+          awk -v ver="$VERSION" '$0 ~ ("^## \\[" ver "\\]"){found=1; next} /^## \[/{found=0} found' CHANGELOG.md > release_notes.md
+          echo "Release notes extracted for v$VERSION"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Remediates confirmed MEDIUM finding #47 (security): tag-controlled version interpolated into an awk program inside a shell run-step (GitHub Actions injection); version now passed via env into awk -v. From the 2026-05-30 audit, re-grounded 2026-06-07. Only .github/workflows/release.yml changed. Local CI (npm test) passes; no failures introduced versus base.

Refs: audit AUDIT_REPORT_2026-05-30 MEDIUM remediation