### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-09
+
+Security patch closing the 2026-05-30 audit findings and a CVE sweep.
+
+### Security
+
+- **Release workflow hardened against GitHub Actions script injection** (PR #92, finding #47). The tag-controlled version is now bound to an `env: VERSION` and passed into `awk` via `-v ver="$VERSION"` instead of being interpolated as `${{ ... }}` directly into the `run` step, closing the injection vector in the changelog-extraction step.
+- **hono bumped to `^4.12.23`** (4 MEDIUM CVEs: CVE-2026-47673 / 47674 / 47675 / 47676, PR #91). Direct dependency of the server.
+
 ## [0.5.0] - 2026-06-02
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-planforge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-planforge",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-planforge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Planning bootstrap for agentic architecture and task generation",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
# Release v0.5.1

Security patch closing the 2026-05-30 audit findings and a CVE sweep. agent-planforge is deployed from `main`; the `v0.5.1` tag triggers the GitHub Release workflow (no npm publish).

## Changes since v0.5.0

| PR | Kind | Summary |
|----|------|---------|
| #92 | **Security** | Release workflow hardened against GitHub Actions script injection (finding #47). The tag-controlled version is bound to `env: VERSION` and passed into `awk` via `-v ver="$VERSION"` instead of `${{ ... }}` interpolated into the `run` step. |
| #91 | CVE | hono bumped to `^4.12.23` in the server (4 MEDIUM CVEs), a direct dependency. |

## Test plan

- [x] Suite green: `npm test` (test:cli && test:server) -> server 47 passed, cli green (exit 0), vitest 4.1.4.
- [x] #47 verified against the current `.github/workflows/release.yml`: `env: VERSION` + `awk -v ver="$VERSION"`, no `${{ }}` in the run body.
- [x] hono verified as a direct `server` dependency at `^4.12.23`.
- [x] Scope: diff is CHANGELOG + root package.json + root lockfile (version-only); `server/package.json` untouched at 0.2.0.
- [x] Release notes: ran the (post-#47) `release.yml` awk for `0.5.1`; clean body, stops at `## [0.5.0]`.

## Operator action

None.

Refs: #47, #91, #92
