### PR TITLE
fix(selector): make nextjs-frontend reachable + fix negated frontend mention

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -1654,6 +1654,28 @@ function inferSymfonyDatabase(input, blueprint) {
   return "postgresql";
 }
 
+function hasFrontendSignal(text) {
+  // Strip negated frontend mentions so "no frontend" / "no react frontend" /
+  // "headless" do not read as a positive frontend signal. An optional framework
+  // adjective (react / vue / ...) between the negation and the noun is absorbed
+  // so "no react frontend" strips cleanly.
+  const stripped = text
+    .replace(/\bheadless\b/gi, " ")
+    .replace(/\b(no|without|sans|zero)\s+(a\s+|an\s+)?((next\.?js|react|vue|angular|spa|client[- ]?side)\s+)?(frontend|front[- ]?end|ui|spa|client[- ]?side|web ui|web interface)\b/gi, " ")
+    .replace(/\bfrontend[- ]?less\b/gi, " ");
+  // Word-anchored so short tokens don't match substrings ("spa" in "aerospace").
+  return /\b(next\.?js|react|vue|angular|frontend|spa|client-side)\b/.test(stripped);
+}
+
+function hasBackendSignal(text) {
+  // Strip negated backend mentions so "no backend" / "frontend-only" do not fire.
+  const stripped = text
+    .replace(/\b(no|without|sans|zero)\s+(a\s+|an\s+)?(backend|back[- ]?end|server|api|database|persistence)\b/gi, " ")
+    .replace(/\bfrontend[- ]?only\b/gi, " ")
+    .replace(/\bstatic[- ]?only\b/gi, " ");
+  return /\b(api|rest|graphql|backend|server|microservice|database|persistence|endpoints?)\b/.test(stripped);
+}
+
 function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
   const combinedText = [
     input.projectName,
@@ -1671,13 +1693,14 @@ function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
   let manualStructureReason = "";
 
   if (/\b(php|symfony|laravel|composer|artisan|phpunit|phpstan)\b/.test(combinedText)) {
-    if (/(next\.?js|react|vue|angular|frontend|spa|client-side)/.test(combinedText)) {
+    if (hasFrontendSignal(combinedText)) {
       candidates = ["symfony-nextjs", "symfony-backend"];
       reason = "PHP/Symfony + JS frontend signals -> symfony-nextjs";
       confidence = "strong";
     } else if (
       /(api|rest|json endpoint|backend|service|graphql)/.test(combinedText) &&
-      !/(frontend|portal|admin ui|dashboard)/.test(combinedText)
+      !hasFrontendSignal(combinedText) &&
+      !/(portal|admin ui|dashboard)/.test(combinedText)
     ) {
       candidates = ["symfony-backend"];
       reason = "PHP/Symfony backend/API without frontend -> symfony-backend";
@@ -1695,6 +1718,10 @@ function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
   } else if (/\b(cli|command line|terminal tool|developer tool|code generator|scaffold)\b/.test(combinedText)) {
     candidates = ["cli-tool", "express-api", "rest-api"];
     reason = "The request reads like an internal or developer-facing tool with command-style workflows.";
+    confidence = "strong";
+  } else if (hasFrontendSignal(combinedText) && !hasBackendSignal(combinedText)) {
+    candidates = ["nextjs-frontend", "nextjs-fullstack", "static-site"];
+    reason = "Frontend-only signal (UI framework with no backend or API surface) -> nextjs-frontend.";
     confidence = "strong";
   } else if (/typescript web application/.test(techStack)) {
     candidates = ["nextjs-fullstack", "saas-dashboard", "nextjs-frontend"];
@@ -3571,4 +3598,8 @@ function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { scaffoldkitBlueprintRecommendation, hasFrontendSignal, hasBackendSignal };

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -1009,4 +1009,135 @@ runCase("invalid config override rejects unsupported keys instead of silently ig
   assert.match(result.stderr, /unsupported key `waves`/);
 });
 
+// --- Unit tests for exported helpers and selector fixes ---
+
+const {
+  scaffoldkitBlueprintRecommendation,
+  hasFrontendSignal,
+  hasBackendSignal
+} = require("../scripts/bootstrap-plan.js");
+
+// hasFrontendSignal unit tests
+runCase("hasFrontendSignal returns true for 'react frontend'", () => {
+  assert.ok(hasFrontendSignal("react frontend"));
+});
+runCase("hasFrontendSignal returns true for 'next.js app'", () => {
+  assert.ok(hasFrontendSignal("next.js app with typescript"));
+});
+runCase("hasFrontendSignal returns true for 'spa' keyword", () => {
+  assert.ok(hasFrontendSignal("single page spa application"));
+});
+runCase("hasFrontendSignal returns false for 'no frontend'", () => {
+  assert.ok(!hasFrontendSignal("symfony rest api, no frontend"));
+});
+runCase("hasFrontendSignal returns false for 'without a frontend'", () => {
+  assert.ok(!hasFrontendSignal("express backend without a frontend"));
+});
+runCase("hasFrontendSignal returns false for 'headless api'", () => {
+  assert.ok(!hasFrontendSignal("headless api service"));
+});
+runCase("hasFrontendSignal returns false for 'no react frontend' (negated framework)", () => {
+  assert.ok(!hasFrontendSignal("symfony backend, no react frontend"));
+});
+runCase("hasFrontendSignal does not match substrings ('spa' in 'aerospace')", () => {
+  assert.ok(!hasFrontendSignal("aerospace telemetry ingestion service"));
+});
+
+// hasBackendSignal unit tests
+runCase("hasBackendSignal returns true for 'rest api'", () => {
+  assert.ok(hasBackendSignal("rest api service"));
+});
+runCase("hasBackendSignal returns true for 'graphql backend'", () => {
+  assert.ok(hasBackendSignal("graphql backend server"));
+});
+runCase("hasBackendSignal returns true for 'postgres database'", () => {
+  assert.ok(hasBackendSignal("postgres database persistence layer"));
+});
+runCase("hasBackendSignal returns false for 'no backend'", () => {
+  assert.ok(!hasBackendSignal("next.js app, no backend"));
+});
+runCase("hasBackendSignal returns false for 'frontend-only static site'", () => {
+  assert.ok(!hasBackendSignal("frontend-only static site with tailwind"));
+});
+
+// Bug 1 fix: frontend-only Next.js intake -> nextjs-frontend (unit test via direct export)
+runCase("selector Bug 1: frontend-only Next.js intake selects nextjs-frontend", () => {
+  const input = {
+    projectName: "admin-ui",
+    summary: "Next.js dashboard frontend for internal operators, TypeScript, Tailwind, no backend.",
+    coreFeatures: ["React component library", "Tailwind styling", "client-side data table"],
+    constraints: ["TypeScript", "no backend", "Tailwind CSS"],
+    integrations: []
+  };
+  // Provide stub output and scaffoldkitContext (no root -> candidates[0] is chosen)
+  const output = {
+    architectureRecommendation: { shape: "monolith" },
+    plannerProfile: "product"
+  };
+  const scaffoldkitContext = { root: "", availableBlueprints: [] };
+  const result = scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext);
+  assert.equal(result.blueprint, "nextjs-frontend", `expected nextjs-frontend, got ${result.blueprint}`);
+  assert.equal(result.confidence, "strong");
+});
+
+// Bug 2 fix: PHP/Symfony + "no frontend" -> symfony-backend (unit test)
+runCase("selector Bug 2: PHP/Symfony + 'no frontend' negation selects symfony-backend", () => {
+  const input = {
+    projectName: "partner-api",
+    summary: "Symfony REST API backend, no frontend.",
+    coreFeatures: ["REST API for partner data", "PHPUnit test suite"],
+    constraints: ["PHP 8.3", "Symfony 7"],
+    integrations: []
+  };
+  const output = {
+    architectureRecommendation: { shape: "monolith" },
+    plannerProfile: "product"
+  };
+  const scaffoldkitContext = { root: "", availableBlueprints: [] };
+  const result = scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext);
+  assert.equal(result.blueprint, "symfony-backend", `expected symfony-backend, got ${result.blueprint}`);
+  // The negated intake must reach the STRONG "backend without frontend" branch,
+  // not the generic medium baseline (which carries an inaccurate manual-adaptation
+  // caveat). This pins the Branch B inline-negation fix.
+  assert.equal(result.confidence, "strong", `expected strong confidence, got ${result.confidence}`);
+  assert.match(result.reason, /without frontend/);
+  assert.equal(result.agentMustCreateStructure, false);
+});
+
+// Bug 2 positive control: PHP/Symfony + real React frontend -> symfony-nextjs still works
+runCase("selector Bug 2 positive control: PHP/Symfony + react frontend selects symfony-nextjs", () => {
+  const input = {
+    projectName: "partner-dashboard",
+    summary: "Symfony API with a React dashboard for partner support teams.",
+    coreFeatures: ["Symfony backend for partner data", "React dashboard for operators"],
+    constraints: ["PHP 8.3", "Symfony 7"],
+    integrations: []
+  };
+  const output = {
+    architectureRecommendation: { shape: "monolith" },
+    plannerProfile: "product"
+  };
+  const scaffoldkitContext = { root: "", availableBlueprints: [] };
+  const result = scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext);
+  assert.equal(result.blueprint, "symfony-nextjs", `expected symfony-nextjs, got ${result.blueprint}`);
+});
+
+// Regression: a clear backend intake must NOT select nextjs-frontend
+runCase("regression: rest json api service intake does not select nextjs-frontend", () => {
+  const input = {
+    projectName: "data-api",
+    summary: "REST JSON API service for ingesting and querying event data.",
+    coreFeatures: ["POST /events endpoint", "GET /events query", "PostgreSQL persistence"],
+    constraints: ["TypeScript", "stateless service"],
+    integrations: []
+  };
+  const output = {
+    architectureRecommendation: { shape: "monolith" },
+    plannerProfile: "product"
+  };
+  const scaffoldkitContext = { root: "", availableBlueprints: [] };
+  const result = scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext);
+  assert.notEqual(result.blueprint, "nextjs-frontend", `expected NOT nextjs-frontend, got ${result.blueprint}`);
+});
+
 console.log("All tests passed.");


### PR DESCRIPTION
Closes task `8b5a8dad`. Two pre-existing `scaffoldkitBlueprintRecommendation` quirks found in a Lane-B e2e dogfood.

## Bugs fixed
1. **`nextjs-frontend` was unreachable.** A frontend-only Next.js intake ("dashboard/marketing frontend, TypeScript, no backend") fell through to `express-api` (service-stack branch) or `nextjs-fullstack`, and `nextjs-frontend` was only ever 3rd in a candidate list. Added a dedicated frontend-only branch (`hasFrontendSignal && !hasBackendSignal`) with `nextjs-frontend` as `candidates[0]`.
2. **Negated frontend mention.** The PHP/Symfony branch matched the literal "frontend" inside "no frontend", picking `symfony-nextjs` for "Symfony REST API backend, no frontend". Both the symfony-nextjs guard and Branch B's own negation are now negation-aware via the new `hasFrontendSignal`, so the intake reaches the strong `symfony-backend` branch.

## How
Two pure, negation-aware helpers `hasFrontendSignal` / `hasBackendSignal` strip "no frontend" / "headless" / "no react frontend" / "frontend-only" before testing word-anchored keyword regexes. `main()` is guarded with `require.main === module` and the selector + helpers are exported so they can be unit-tested directly (the server and tests still spawn the CLI as a subprocess).

## Tests
All pre-existing test:cli + 47 test:server pass unchanged. New unit tests cover the helpers, both bugs, the strong Branch B path, and regex-looseness edges. A reviewer subagent mutation-tested the fixes (all flips confirmed) and caught the Branch B confidence-downgrade, fixed here.

Refs: agent-tasks 8b5a8dad