### PR TITLE
docs: fix README/docs drift vs code in agent-planforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ If you are updating scripts or agents from the older flat root layout, see [docs
 - `models/planner-config.schema.json`
 - `playbooks/planning-and-scoping.md`
 - `scripts/bootstrap-plan.js`
+- `server/` (HTTP service sub-package)
 - `templates/`
 - `tasks/`
 
@@ -315,8 +316,25 @@ The tests cover:
 - dependency graph and rerun/resume reporting
 - playbook references and `.ai/` artifact generation
 
+## HTTP Service
+
+A thin Hono + TypeScript HTTP surface around the planner lives in
+[`server/`](server/README.md). It lets project-forge (and agents) drive the
+planner over the network instead of shelling out to the CLI on the same
+machine:
+
+- `POST /api/generate` — run the planner (Bearer `PLANFORGE_SERVICE_TOKEN`), streaming progress as SSE
+- `GET /healthz` — unauthenticated liveness probe (Traefik / ops dashboard target)
+
+It listens on port `8223` by default. See [`server/README.md`](server/README.md)
+for the full endpoint, environment, and deployment reference.
+
 ## Docker
 
+The container image packages the HTTP service (see [HTTP Service](#http-service)).
+The only Dockerfile is `server/Dockerfile`, so build it explicitly:
+
 ```bash
-docker build -t agent-planforge .
+docker build -f server/Dockerfile -t agent-planforge .
+docker run -p 8223:8223 -e PLANFORGE_SERVICE_TOKEN=<token> agent-planforge
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ this package is follow-up ticket #1 from that ADR.
 
 | Route | Auth | Purpose |
 | --- | --- | --- |
-| `GET  /healthz` | none | Liveness + version info. Traefik / ops dashboard target. |
+| `GET  /healthz` | none | Liveness + scaffoldkit-python probe. Traefik / ops dashboard target. |
 | `POST /api/generate` | `Bearer ${PLANFORGE_SERVICE_TOKEN}` | Run the planner. Streams progress as SSE. |
 
 ### `POST /api/generate`
@@ -95,6 +95,7 @@ scaffold is fatal to its flow.
 | `PLANFORGE_ROOT` | parent of this package | Repo root that contains `scripts/bootstrap-plan.js` |
 | `NODE_BIN` | `process.execPath` | Node binary used to spawn the CLI |
 | `SCAFFOLDKIT_PYTHON` | `/opt/sk-venv/bin/python3` | Python binary that runs `scaffoldkit.cli from-planforge`. The Dockerfile lays down the pinned venv; local dev points this at any Python that has scaffoldkit installed, or skips scaffolding via `scaffold: false` in the request body. |
+| `PLANFORGE_ALLOW_MISSING_SCAFFOLDKIT` | *(unset)* | Set to `1` to acknowledge a dev env without scaffoldkit: downgrades the missing-`SCAFFOLDKIT_PYTHON` boot warning to a single info line. Unset, the service still boots but logs a loud multi-line warning. |
 
 ## Running
 


### PR DESCRIPTION
Fixes 2 verified documentation-vs-code drifts (plus in-repo sibling instances) from an org-wide README/docs audit. Each finding independently verified against source; branch reviewed by a separate reviewer subagent (verdict: APPROVE_WITH_NITS).

Scope: docs follow code (no features invented; non-existent commands/features removed or marked Planned; phantom Makefile targets corrected; version/identity constants aligned where code was the stale outlier). Sibling copies across secondary docs, UI strings, and code comments also fixed.

Refs: DOCS_DRIFT_REPORT_2026-06-18