### PR TITLE
fix(scaffold): route Java/Spring to springboot-backend; default unspecified stack to TS/Node

### DIFF
--- a/scripts/bootstrap-plan.js
+++ b/scripts/bootstrap-plan.js
@@ -1511,6 +1511,11 @@ function adrCandidates(input, architecture) {
   return adrs;
 }
 
+// Signals for a JVM / Spring stack. `spring` must be qualified (e.g. "spring boot")
+// so a "spring fashion" marketing site does not route to a Java backend. Shared by
+// inferTechStack and scaffoldkitBlueprintRecommendation so the two cannot drift.
+const JAVA_SPRING_SIGNAL = /\b(spring boot|spring-boot|springboot|spring mvc|spring webflux|spring data|spring framework|spring security|java|kotlin|jakarta|micronaut|quarkus|gradle|maven|jpa|hibernate)\b/;
+
 function inferTechStack(input) {
   const constraints = (input.constraints || []).join(" ").toLowerCase();
   const combinedText = [
@@ -1522,6 +1527,10 @@ function inferTechStack(input) {
 
   if (/\b(php|symfony|laravel|composer|artisan|phpunit|phpstan)\b/.test(combinedText)) {
     return "PHP/Symfony application";
+  }
+
+  if (JAVA_SPRING_SIGNAL.test(combinedText)) {
+    return "Java/Spring application";
   }
 
   if (/typescript/.test(constraints)) {
@@ -1711,6 +1720,10 @@ function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
       confidence = "medium";
       manualStructureReason = "The framework family is clear, but the generated scaffold may still need manual adaptation for the final repository layout.";
     }
+  } else if (JAVA_SPRING_SIGNAL.test(combinedText)) {
+    candidates = ["springboot-backend"];
+    reason = "Java/Spring signals -> springboot-backend.";
+    confidence = "strong";
   } else if (/(landing page|marketing site|content site|blog|documentation site|static site)/.test(combinedText)) {
     candidates = ["static-site", "nextjs-frontend", "nextjs-fullstack"];
     reason = "The request reads like a content-oriented or marketing-style site rather than an application backend.";
@@ -1759,8 +1772,11 @@ function scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext) {
     confidence = "medium";
     manualStructureReason = "Treat the scaffold as a baseline, not as the complete repository layout.";
   } else {
-    candidates = ["rest-api", "express-api", "nextjs-fullstack"];
-    reason = "No stronger scaffold signal was found, so the fallback stays close to the recommended architecture and stack.";
+    // No explicit stack signal at all. Default to a neutral TypeScript/Node API
+    // scaffold (express-api) rather than rest-api, whose framework defaults to
+    // FastAPI/Python — an unexpected Python project for an unspecified request.
+    candidates = ["express-api", "rest-api", "nextjs-fullstack"];
+    reason = "No explicit stack signal was found; defaulting to a neutral TypeScript/Node API scaffold (express-api).";
     confidence = "weak";
     manualStructureReason = "No blueprint closely matches the request. The agent should expect to create or adapt the project structure manually.";
   }
@@ -1803,6 +1819,9 @@ function blueprintLanguage(blueprint, input) {
   const techStack = inferTechStack(input).toLowerCase();
   const constraintsText = (input.constraints || []).join(" ").toLowerCase();
   switch (blueprint) {
+    case "springboot-backend":
+      // Java/Spring scaffold: feature task paths use the Java source layout.
+      return "java";
     case "rest-api":
       // framework = express (TS) for a TypeScript service stack, else fastapi (Python).
       return /typescript service stack/.test(techStack) ? "typescript" : "python";
@@ -1870,6 +1889,24 @@ function scaffoldkitSuggestedVariables(input, output, blueprint) {
     suggested.php_version = /php 8\.2/.test(constraintsText) ? "8.2" : "8.3";
     suggested.database = inferSymfonyDatabase(input, blueprint);
     suggested.use_docker = /docker|container|compose/.test(combinedText);
+  } else if (blueprint === "springboot-backend") {
+    // Leave base_package and build_tool at the blueprint defaults (com.example.app,
+    // maven). The Java feature/test task paths and the pom.xml manifest hint are
+    // generated for that exact package and build tool, so overriding either here
+    // would make the planned paths diverge from what scaffoldkit actually emits.
+    // Only customize variables that do not affect the source layout.
+    suggested.java_version = /java\s*17|jdk\s*17/.test(combinedText) ? "17" : "21";
+    // springboot-backend's database choices are postgresql/mysql/mariadb; inferDatabaseChoice
+    // only ever emits sqlite/mysql/mongodb/postgresql, so pass mysql through and default
+    // everything else (sqlite, mongodb, postgresql) to postgresql.
+    suggested.database = inferDatabaseChoice(input, "database") === "mysql" ? "mysql" : "postgresql";
+    suggested.use_auth = !/public-only|anonymous|no auth/.test(combinedText);
+    suggested.auth_method = /oauth/.test(combinedText)
+      ? "oauth2"
+      : /api[- ]?key/.test(combinedText)
+        ? "api-key"
+        : "jwt";
+    suggested.use_docker = /docker|container|kubernetes|compose/.test(combinedText);
   } else if (blueprint === "static-site") {
     suggested.description = input.summary || "A static website";
   }
@@ -1985,6 +2022,23 @@ function genericFeatureFiles(feature, architectureShape, stack) {
     return Array.from(new Set(files));
   }
 
+  if (language === "java") {
+    const name = pascalCaseFromSlug(slug);
+    const files = [
+      `src/main/java/com/example/app/web/${name}Controller.java`,
+      `src/main/java/com/example/app/service/${name}Service.java`,
+      `src/main/java/com/example/app/repository/${name}Repository.java`,
+      `src/test/java/com/example/app/${name}ControllerTest.java`
+    ];
+    if (isBackgroundWork) {
+      files.push(`src/main/java/com/example/app/service/${name}Worker.java`);
+    }
+    if (isAudit) {
+      files.push("src/main/java/com/example/app/service/AuditLogService.java");
+    }
+    return Array.from(new Set(files));
+  }
+
   // TypeScript (default): modular layout.
   const files = [
     `src/modules/${slug}/index.ts`,
@@ -2023,6 +2077,13 @@ function coverageTaskFiles(stack) {
       "tests/Contract/IntegrationsTest.php"
     ];
   }
+  if (language === "java") {
+    return [
+      "src/test/java/com/example/app/integration/CriticalPathIT.java",
+      "src/test/java/com/example/app/integration/ErrorHandlingIT.java",
+      "src/test/java/com/example/app/contract/IntegrationsIT.java"
+    ];
+  }
   // TypeScript (default): match the .test.ts convention used elsewhere in this file.
   return [
     "tests/integration/critical-path.test.ts",
@@ -2041,6 +2102,9 @@ function manifestFileForStack(stack) {
   }
   if (language === "php") {
     return "composer.json";
+  }
+  if (language === "java") {
+    return "pom.xml";
   }
   return "package.json";
 }
@@ -3602,4 +3666,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { scaffoldkitBlueprintRecommendation, hasFrontendSignal, hasBackendSignal };
+module.exports = { scaffoldkitBlueprintRecommendation, hasFrontendSignal, hasBackendSignal, blueprintLanguage, inferTechStack };

--- a/tests/bootstrap-plan.test.js
+++ b/tests/bootstrap-plan.test.js
@@ -1014,7 +1014,9 @@ runCase("invalid config override rejects unsupported keys instead of silently ig
 const {
   scaffoldkitBlueprintRecommendation,
   hasFrontendSignal,
-  hasBackendSignal
+  hasBackendSignal,
+  blueprintLanguage,
+  inferTechStack
 } = require("../scripts/bootstrap-plan.js");
 
 // hasFrontendSignal unit tests
@@ -1138,6 +1140,194 @@ runCase("regression: rest json api service intake does not select nextjs-fronten
   const scaffoldkitContext = { root: "", availableBlueprints: [] };
   const result = scaffoldkitBlueprintRecommendation(input, output, scaffoldkitContext);
   assert.notEqual(result.blueprint, "nextjs-frontend", `expected NOT nextjs-frontend, got ${result.blueprint}`);
+});
+
+// --- Stack routing fix: Java/Spring -> springboot-backend; unspecified -> express-api ---
+
+runCase("java/spring intakes select the springboot-backend blueprint with java task paths", () => {
+  const fixtureDir = tempDir("planforge-springboot-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "Order Service",
+    summary: "A backend service for managing orders.",
+    targetUsers: ["internal systems"],
+    coreFeatures: ["create and update orders", "query orders"],
+    constraints: ["Java 21", "Spring Boot", "must run in Docker"]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  const outdir = path.join(fixtureDir, "out");
+  const scaffoldkit = readJson(exportsFile(outdir, "scaffoldkit-input.json"));
+  const output = readJson(planningFile(outdir, "plan-output.json"));
+
+  assert.equal(scaffoldkit.blueprint, "springboot-backend");
+  assert.equal(scaffoldkit.blueprintConfidence, "strong");
+  assert.equal(scaffoldkit.stack.hint, "Java/Spring application");
+  assert.equal(scaffoldkit.suggestedVariables.java_version, "21");
+  assert.equal(scaffoldkit.suggestedVariables.database, "postgresql");
+  // base_package and build_tool are intentionally NOT overridden: the Java task
+  // paths and the pom.xml manifest are generated for the blueprint defaults
+  // (com.example.app, maven), so overriding them would diverge from the scaffold.
+  assert.equal(scaffoldkit.suggestedVariables.base_package, undefined);
+  assert.equal(scaffoldkit.suggestedVariables.build_tool, undefined);
+  assert.equal(output.scaffoldBlueprint, "springboot-backend");
+
+  // springboot-backend has neither a language nor a framework variable; the
+  // planner must not leak python/typescript stack vars onto it.
+  assert.equal(Object.prototype.hasOwnProperty.call(scaffoldkit.suggestedVariables, "language"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(scaffoldkit.suggestedVariables, "framework"), false);
+
+  // Java feature task paths, not the Python/FastAPI or TypeScript layout.
+  const featureFiles = output.tasks.filter((task) => task.category === "feature").flatMap((task) => task.files);
+  assert.ok(featureFiles.length > 0);
+  assert.ok(
+    featureFiles.every((file) => file.endsWith(".java")),
+    `expected java feature paths, got: ${featureFiles.join(", ")}`
+  );
+  // The feature path package must match the scaffold's base_package default exactly,
+  // not a slug-derived package the scaffold never creates.
+  assert.ok(featureFiles.some((file) => /^src\/main\/java\/com\/example\/app\/.+Controller\.java$/.test(file)));
+  assert.ok(
+    featureFiles.every((file) => /^src\/(main|test)\/java\/com\/example\/app\//.test(file)),
+    `java feature paths diverge from base_package com.example.app: ${featureFiles.join(", ")}`
+  );
+  assert.ok(
+    featureFiles.every((file) => !/\.(py|tsx?)$/.test(file)),
+    `java intake leaked python/ts paths: ${featureFiles.join(", ")}`
+  );
+
+  // The foundation manifest must be pom.xml, not package.json or pyproject.toml.
+  const setupTask = output.tasks.find((task) => /set up repository/i.test(task.title));
+  assert.ok(setupTask, "expected a 'set up repository' foundation task");
+  assert.ok(setupTask.files.includes("pom.xml"), `setup task should list pom.xml, got: ${setupTask.files.join(", ")}`);
+  assert.ok(!setupTask.files.includes("package.json"));
+  assert.ok(!setupTask.files.includes("pyproject.toml"));
+});
+
+runCase("unspecified-stack intakes default to express-api (TS/Node), not a python rest-api", () => {
+  const fixtureDir = tempDir("planforge-neutral-default-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "Generic Thing",
+    summary: "A small service that does some processing for an internal team.",
+    targetUsers: ["internal team"],
+    coreFeatures: ["process incoming items", "store results", "expose a way to read results"],
+    constraints: []
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  const outdir = path.join(fixtureDir, "out");
+  const scaffoldkit = readJson(exportsFile(outdir, "scaffoldkit-input.json"));
+  const output = readJson(planningFile(outdir, "plan-output.json"));
+
+  // The no-signal fallback must be the neutral TS/Node express-api, never the
+  // Python/FastAPI rest-api that previously surprised users who left constraints empty.
+  assert.equal(scaffoldkit.blueprint, "express-api");
+  assert.notEqual(scaffoldkit.suggestedVariables.framework, "fastapi");
+
+  const featureFiles = output.tasks.filter((task) => task.category === "feature").flatMap((task) => task.files);
+  assert.ok(featureFiles.length > 0);
+  assert.ok(
+    featureFiles.every((file) => !file.endsWith(".py")),
+    `unspecified stack leaked python paths: ${featureFiles.join(", ")}`
+  );
+  assert.ok(featureFiles.some((file) => /\.ts$/.test(file)));
+});
+
+// inferTechStack / selector / blueprintLanguage unit tests for the fix
+runCase("inferTechStack detects Java/Spring keywords", () => {
+  assert.equal(inferTechStack({ constraints: ["Java", "Spring Boot"] }), "Java/Spring application");
+  assert.equal(
+    inferTechStack({ summary: "A service built with Gradle and Hibernate", constraints: [] }),
+    "Java/Spring application"
+  );
+});
+
+runCase("inferTechStack does not match 'java' inside 'javascript'", () => {
+  assert.notEqual(inferTechStack({ constraints: ["javascript only"] }), "Java/Spring application");
+});
+
+runCase("selector: Java/Spring intake selects springboot-backend at strong confidence", () => {
+  const input = {
+    projectName: "order-svc",
+    summary: "Spring Boot backend for orders.",
+    coreFeatures: ["order CRUD"],
+    constraints: ["Java 21", "Spring Boot"],
+    integrations: []
+  };
+  const output = { architectureRecommendation: { shape: "modular monolith" }, plannerProfile: "product" };
+  const result = scaffoldkitBlueprintRecommendation(input, output, { root: "", availableBlueprints: [] });
+  assert.equal(result.blueprint, "springboot-backend", `expected springboot-backend, got ${result.blueprint}`);
+  assert.equal(result.confidence, "strong");
+});
+
+runCase("selector: unspecified stack falls back to express-api, not rest-api", () => {
+  const input = {
+    projectName: "thing",
+    summary: "A small internal processing service.",
+    coreFeatures: ["process items", "store results"],
+    constraints: [],
+    integrations: []
+  };
+  const output = { architectureRecommendation: { shape: "modular monolith" }, plannerProfile: "product" };
+  const result = scaffoldkitBlueprintRecommendation(input, output, { root: "", availableBlueprints: [] });
+  assert.equal(result.blueprint, "express-api", `expected express-api, got ${result.blueprint}`);
+});
+
+runCase("blueprintLanguage maps springboot-backend to java and leaves rest-api defaults intact", () => {
+  assert.equal(blueprintLanguage("springboot-backend", { constraints: ["Java"] }), "java");
+  // Regression: rest-api keeps its python default for an unspecified/python stack,
+  // and typescript for a TS service stack — unchanged by this fix.
+  assert.equal(blueprintLanguage("rest-api", { constraints: ["python"] }), "python");
+  assert.equal(blueprintLanguage("rest-api", { constraints: ["typescript"] }), "typescript");
+});
+
+runCase("negative control: a bare-'spring' marketing/blog site does not route to springboot-backend", () => {
+  // 'spring' as a season/brand must NOT trip the JVM signal; only qualified forms
+  // (spring boot, spring mvc, ...) or java/kotlin/etc. should route to springboot.
+  const input = {
+    projectName: "Spring Fashion",
+    summary: "A marketing landing page for our spring fashion collection and a blog.",
+    coreFeatures: ["hero landing page", "lookbook gallery", "blog"],
+    constraints: [],
+    integrations: []
+  };
+  assert.equal(inferTechStack(input), "application stack to be confirmed");
+  const output = { architectureRecommendation: { shape: "modular monolith" }, plannerProfile: "product" };
+  const result = scaffoldkitBlueprintRecommendation(input, output, { root: "", availableBlueprints: [] });
+  assert.notEqual(result.blueprint, "springboot-backend", `bare 'spring' wrongly routed to springboot: ${result.blueprint}`);
+});
+
+runCase("digit-leading Java project name does not produce an invalid base_package or divergent paths", () => {
+  const fixtureDir = tempDir("planforge-springboot-digit-");
+  writeJson(path.join(fixtureDir, "input.json"), {
+    projectName: "3D Print Manager",
+    summary: "A Spring Boot backend for managing 3D print jobs.",
+    targetUsers: ["makers"],
+    coreFeatures: ["queue print jobs", "track printer status"],
+    constraints: ["Java 21", "Spring Boot"]
+  });
+
+  const result = runPlanner(["--input", "input.json", "--outdir", "out"], { cwd: fixtureDir });
+  assert.equal(result.status, 0, result.stderr);
+
+  const outdir = path.join(fixtureDir, "out");
+  const scaffoldkit = readJson(exportsFile(outdir, "scaffoldkit-input.json"));
+  const output = readJson(planningFile(outdir, "plan-output.json"));
+
+  assert.equal(scaffoldkit.blueprint, "springboot-backend");
+  // No slug-derived base_package override (which would be the uncompilable
+  // com.example.3dprintmanager); the scaffold uses the valid default com.example.app
+  // and the planned Java paths match it.
+  assert.equal(scaffoldkit.suggestedVariables.base_package, undefined);
+  const featureFiles = output.tasks.filter((task) => task.category === "feature").flatMap((task) => task.files);
+  assert.ok(featureFiles.length > 0);
+  assert.ok(
+    featureFiles.every((file) => /^src\/(main|test)\/java\/com\/example\/app\//.test(file)),
+    `digit-leading java intake produced divergent paths: ${featureFiles.join(", ")}`
+  );
 });
 
 console.log("All tests passed.");


### PR DESCRIPTION
## Problem

project-forge intakes were scaffolded as Python/FastAPI regardless of the requested stack:

- empty constraints produced a Python rest-api scaffold
- Java/Spring constraints still produced Python

Root cause in `agent-planforge/scripts/bootstrap-plan.js`: `inferTechStack` only recognized `typescript`/`python`, and `scaffoldkitBlueprintRecommendation` had no Java/Spring branch, so both cases fell through to the no-signal `rest-api` fallback, whose framework defaults to FastAPI. scaffoldkit already ships a complete `springboot-backend` blueprint at the pinned SHA, so this is a routing fix, not a new template.

## Fix (all in bootstrap-plan.js)

- A shared `JAVA_SPRING_SIGNAL` regex (qualified `spring` forms plus java, kotlin, jakarta, micronaut, quarkus, gradle, maven, jpa, hibernate) routes Java/Spring intakes to `springboot-backend` at strong confidence. `spring` is qualified ("spring boot" and friends) so a "spring fashion" marketing site is not caught.
- The no-signal fallback now defaults to `express-api` (neutral TypeScript/Node), not the Python rest-api.
- Java source layout for feature/coverage/manifest task paths (`src/main/java/com/example/app`, JUnit ITs, `pom.xml`), kept coherent with the scaffold by leaving base_package and build_tool at the blueprint defaults.

## Explicitly unchanged (no regression)

- A plain "REST API" intake with no language stays rest-api/FastAPI/Python (existing tests).
- django stays rest-api/weak/Python; python and typescript intakes are unchanged.
- project-forge and scaffoldkit are not touched.

## Tests

9 new cases plus mutation-tested guards. `npm test` is green (54 cli, 47 server). An independent reviewer pass was addressed: package-path divergence (HIGH), invalid digit-leading base_package (MEDIUM), bare-`spring` false positive (MEDIUM), gradle/manifest mismatch (LOW), all resolved by dropping the base_package/build_tool overrides and qualifying the spring signal.

Refs: agent-tasks 1715c27d-d1d3-4e2f-9be4-3921cf7f6b2b