### PR TITLE
fix(security): bump hono to 4.12.26 in server (CORS CVE)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1129,9 +1129,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Security: hono CVE bump (lockfile-only)

`npm audit fix --package-lock-only` in `./server` raises hono 4.12.23 -> 4.12.26 (runtime), clearing a high-severity CORS advisory plus 4 moderates. Only package-lock.json changed; no source or package.json change. `npm audit` is now 0 in ./server.

Reviewed by an independent subagent (lockfile-only, audit=0, non-major). Part of the 2026-06-20 CVE sweep.

Refs: agent-tasks cb1e350d