### PR TITLE
fix(deps): move the server to @hono/node-server 2.x

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@agent-planforge/server",
       "version": "0.2.0",
       "dependencies": {
-        "@hono/node-server": "^1.14.1",
+        "@hono/node-server": "^2.0.5",
         "hono": "^4.12.23",
         "zod": "^3.24.4"
       },
@@ -560,12 +560,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@hono/node-server": "^1.14.1",
+    "@hono/node-server": "^2.0.5",
     "hono": "^4.12.23",
     "zod": "^3.24.4"
   },


### PR DESCRIPTION
CVE sweep wave 2, 2026-07-29. Closes GHSA-frvp-7c67-39w9 (path traversal
in serve-static on Windows, `@hono/node-server` < 2.0.5) in the `server/`
tree. Dependabot flagged it as scope=runtime, not dev.

`@hono/node-server` is a DIRECT dependency here, so the only fix is the
semver-major 1.x -> 2.x. That is why wave 1 deferred it rather than
skipping it. npm audit: 1 moderate before, 0 after.

On the major: this service calls `serve({ fetch, port }, cb)`, which is
unchanged in 2.x. The only export 2.x removes is `./vercel`, unused here.
The peer range is still `hono ^4`, so hono stays on 4.x. engines.node
goes to >=20, and this package already declares >=20.

Node version check, because this repo has a Node 18 leg: the 18/20 matrix
belongs to the `cli` job, which runs only the root install, `test:cli`
and bootstrap-plan.js. The root lockfile contains no @hono/node-server at
all, so that leg cannot break. The `server` job pins node 20.

Verification: typecheck, build and the suite all pass. The suite is
50 passed / 0 failed on BOTH `main` and this branch, so the comparison is
like for like and this introduces no regression.

Worth recording because it cost a wrong diagnosis: on a first pass the
suite showed 8 failures here, and those were misattributed to a missing
SCAFFOLDKIT_PYTHON. That was wrong. The actual cause was that this repo's
ROOT node_modules was not installed, so `scripts/bootstrap-plan.js` died
with `Cannot find module 'ajv/dist/2020'`. The giveaway, missed at the
time, is that the failing happy-path tests pass `scaffold: false`
precisely to stay off scaffoldkit. With `npm ci` run at the root as well
as in server/, which is what CI does, the suite is fully green on both
refs.

Streaming was still worth checking directly, since it is the most likely
thing an adapter major would break and these tests drive Hono through
`app.fetch()`, which bypasses the adapter entirely. Against this tree's
installed 2.0.12, a ReadableStream response delivered chunks at +121ms,
+243ms and +369ms with the terminal event at +370ms: still incremental,
not buffered to close. Client-disconnect abort propagation through
`c.req.raw.signal` was confirmed to still fire as well.

`npm install --package-lock-only` is a no-op.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

