### PR TITLE
chore(security): lockfile-only npm audit fix (CVE sweep 2026-08-04)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Part of the fleet-wide CVE sweep of 2026-08-04.

**What this is:** `npm audit fix --package-lock-only` per lockfile tree. Nothing else.

- `package.json` is **untouched** — the diff is lockfile-only, verified with `git diff --name-only`.
- **No major versions move.** Fleet-wide only seven packages shift, all patch/minor: `brace-expansion`, `ip-address`, `fast-uri`, `hono`, `undici`, `express-rate-limit`, `socket.io-parser`.
- `npm audit --package-lock-only` reports **0 critical / 0 high** in every tracked lockfile tree of this repo afterwards.

**Why now:** the July sweep parked `brace-expansion` as "not locally fixable" because 1.x hung off `minimatch` 3.x. That is resolved upstream — 1.1.18 is the patched release *within* the 1.x range, so no `minimatch` major is needed.

The repo's own build/test suite was run on this branch before the commit.
